### PR TITLE
Adding transformer method for customising indexed terms

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---color
---format n
+--order defined

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: ruby
 rvm:
-  - 1.9.3
-notifications:
-  email:
-    - gernot@kogler-informatik.ch
+  - 2.0.0
+  - 2.2
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - uuid-dev # needed for compiling xapian-ruby

--- a/README.rdoc
+++ b/README.rdoc
@@ -194,6 +194,20 @@ are ordered by relevance and - within the same relevance - by the natural sort o
     end
   end
 
+You can specify a Ruby method for preprocessing the indexed terms. The method needs to be a class method that takes one argument (the terms to be indexed) and
+returns a string. You can configure it globaly in the config or on a blueprint. For example, this setup will make words with accented e characters searchable
+by their accentless form:
+
+  class Util
+    def self.strip_accents(terms)
+      terms.gsub(/[éèêëÉÈÊË]/, "e")
+    end
+  end
+
+  XapianDb::Config.setup do |config|
+    config.indexer_preprocess_callback UtilT.method(:strip_accents)
+  end
+
 You may use attributes from associated objekts in a blueprint; if you do that and an associated object is updated, your objects should be reindexed, too. You can tell XapnaDB about those dependencies like so:
 
   XapianDb::DocumentBlueprint.setup(:Person) do |blueprint|

--- a/lib/xapian_db/config.rb
+++ b/lib/xapian_db/config.rb
@@ -32,7 +32,7 @@ module XapianDb
       end
 
       # Install delegates for the config instance variables
-      [:database, :adapter, :writer, :stemmer, :stopper].each do |attr|
+      [:database, :adapter, :writer, :stemmer, :stopper, :preprocess_terms].each do |attr|
         define_method attr do
           @config.nil? ? nil : @config.instance_variable_get("@_#{attr}")
         end
@@ -181,6 +181,22 @@ module XapianDb
     def disable_query_flag(flag)
       @_enabled_query_flags ||= []
       @_enabled_query_flags.delete flag
+    end
+
+    # Set the indexer preprocess callback.
+    # @param [Method] method a class method; needs to take one parameter and return a string.
+    # @example
+    #   class Util
+    #     def self.strip_accents(terms)
+    #       terms.gsub(/[éèêëÉÈÊË]/, "e")
+    #     end
+    #   end
+    #
+    #   XapianDb::Config.setup do |config|
+    #     config.indexer_preprocess_callback Util.method(:strip_accents)
+    #   end
+    def indexer_preprocess_callback(method)
+      @_preprocess_terms = method
     end
 
   end

--- a/lib/xapian_db/database.rb
+++ b/lib/xapian_db/database.rb
@@ -86,7 +86,7 @@ module XapianDb
         enquiry.set_sort_by_key_then_relevance(sorter, sort_decending)
       else
         sorter.add_value DocumentBlueprint.value_number_for(:natural_sort_order)
-        enquiry.set_sort_by_relevance_then_key sorter, true
+        enquiry.set_sort_by_relevance_then_key sorter, false
       end
 
       opts[:spelling_suggestion] = @query_parser.spelling_suggestion

--- a/lib/xapian_db/document_blueprint.rb
+++ b/lib/xapian_db/document_blueprint.rb
@@ -274,6 +274,7 @@ module XapianDb
       @dependencies         = []
       @_natural_sort_order  = :id
       @autoindex            = true
+      @indexer_preprocess_callback = nil
     end
 
     # Set the adapter
@@ -409,6 +410,29 @@ module XapianDb
 
     def dependency(klass_name, when_changed: [], &block)
       @dependencies << Dependency.new(klass_name.to_s, when_changed, block)
+    end
+
+    # Set the indexer preprocess callback.
+    # @param [Method] method a class method; needs to take one parameter and return a string.
+    # @example
+    #   class Util
+    #     def self.strip_accents(terms)
+    #       terms.gsub(/[éèêëÉÈÊË]/, "e")
+    #     end
+    #   end
+    #
+    #   XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
+    #     blueprint.attribute :name
+    #     blueprint.indexer_preprocess_callback Util.method(:strip_accents)
+    #   end
+    def indexer_preprocess_callback(method)
+      @indexer_preprocess_callback = method
+    end
+
+    # Reader for indexer_preprocess_callback.
+    # Returns the terms preprocessing method for this blueprint, the global method from config or nil.
+    def preprocess_terms
+      @indexer_preprocess_callback || XapianDb::Config.preprocess_terms
     end
 
     # Options for an indexed method

--- a/lib/xapian_db/indexer.rb
+++ b/lib/xapian_db/indexer.rb
@@ -86,6 +86,7 @@ module XapianDb
           values = get_values_to_index_from obj
           values.each do |value|
             terms = value.to_s.downcase
+            terms = @blueprint.preprocess_terms.call(terms) if @blueprint.preprocess_terms
             terms = split(terms) if XapianDb::Config.term_splitter_count > 0 && !options.no_split
             # Add value with field name
             term_generator.index_text(terms, options.weight, "X#{method.upcase}") if options.prefixed

--- a/spec/type_codec_spec.rb
+++ b/spec/type_codec_spec.rb
@@ -7,14 +7,14 @@ describe XapianDb::TypeCodec do
   describe ".codec_for(:type)" do
 
     it "returns a codec for the given type" do
-      described_class.codec_for(:string).should == XapianDb::TypeCodec::StringCodec
-      described_class.codec_for(:date).should == XapianDb::TypeCodec::DateCodec
-      described_class.codec_for(:date_time).should == XapianDb::TypeCodec::DateTimeCodec
-      described_class.codec_for(:number).should == XapianDb::TypeCodec::NumberCodec
+      expect(described_class.codec_for(:string)).to eq(XapianDb::TypeCodec::StringCodec)
+      expect(described_class.codec_for(:date)).to eq(XapianDb::TypeCodec::DateCodec)
+      expect(described_class.codec_for(:date_time)).to eq(XapianDb::TypeCodec::DateTimeCodec)
+      expect(described_class.codec_for(:number)).to eq(XapianDb::TypeCodec::NumberCodec)
     end
 
     it "raises an argument error if the type is unknown" do
-      lambda { described_class.codec_for(:unsupported) }.should raise_error ArgumentError
+      expect { described_class.codec_for(:unsupported) }.to raise_error ArgumentError
     end
 
   end
@@ -26,17 +26,17 @@ describe XapianDb::TypeCodec::JsonCodec do
 
     it "encodes an object to its json representation" do
       hash = { x: "y" }
-      described_class.encode(hash).should == hash.to_json
+      expect(described_class.encode(hash)).to eq(hash.to_json)
     end
 
     it "raises an ArgumentError if the object does not respond to to_json" do
       object = Object.new
-      object.stub!(:to_json).and_raise NoMethodError
-      lambda { described_class.encode(object) }.should raise_error ArgumentError
+      allow(object).to receive(:to_json).and_raise NoMethodError
+      expect { described_class.encode(object) }.to raise_error ArgumentError
     end
 
     it "returns nil if the object is nil" do
-      described_class.encode(nil).should be_nil
+      expect(described_class.encode(nil)).to be_nil
     end
 
   end
@@ -45,20 +45,20 @@ describe XapianDb::TypeCodec::JsonCodec do
 
     it "decodes a json string representing the object to the object" do
       json_string = { x: "y" }.to_json
-      described_class.decode(json_string).should == JSON.parse(json_string)
+      expect(described_class.decode(json_string)).to eq(JSON.parse(json_string))
     end
 
     it "decodes nil to nil" do
-      described_class.decode(nil).should be_nil
+      expect(described_class.decode(nil)).to be_nil
     end
 
     it "decodes an empty string to nil" do
-      described_class.decode("").should be_nil
+      expect(described_class.decode("")).to be_nil
     end
 
     it "raises an ArgumentError if the given argument cannot pe parsed by JSON" do
       argument = 1
-      lambda { described_class.decode(argument) }.should raise_error ArgumentError
+      expect { described_class.decode(argument) }.to raise_error ArgumentError
     end
 
   end
@@ -69,14 +69,14 @@ describe XapianDb::TypeCodec::StringCodec do
   describe "encode(object)" do
 
     it "encodes an object to a string" do
-      described_class.encode("string").should == "string"
+      expect(described_class.encode("string")).to eq("string")
     end
   end
 
   describe "decode(string)" do
 
     it "returns the string given as an argument" do
-      described_class.decode("string").should == "string"
+      expect(described_class.decode("string")).to eq("string")
     end
   end
 end
@@ -86,16 +86,16 @@ describe XapianDb::TypeCodec::BooleanCodec do
   describe "encode(value)" do
 
     it "encodes a booelan to a string" do
-      described_class.encode(true).should == "true"
-      described_class.encode(false).should == "false"
+      expect(described_class.encode(true)).to eq("true")
+      expect(described_class.encode(false)).to eq("false")
     end
   end
 
   describe "decode(value)" do
 
     it "returns the boolean value" do
-      described_class.decode("true").should be_true
-      described_class.decode("false").should be_false
+      expect(described_class.decode("true")).to be_truthy
+      expect(described_class.decode("false")).to be_falsey
     end
   end
 end
@@ -105,34 +105,34 @@ describe XapianDb::TypeCodec::DateCodec do
   describe "encode(date)" do
 
     it "encodes a date to a string with format yyyymmdd" do
-      described_class.encode(Date.new(2011, 1, 1)).should == "20110101"
+      expect(described_class.encode(Date.new(2011, 1, 1))).to eq("20110101")
     end
 
     it "raises an argument error if the given object is not a date" do
-      lambda { described_class.encode("20110101") }.should raise_error "20110101 was expected to be a date"
+      expect { described_class.encode("20110101") }.to raise_error "20110101 was expected to be a date"
     end
 
     it "should return nil when a nil value is supplied" do
-      described_class.encode(nil).should_not be
+      expect(described_class.encode(nil)).not_to be
     end
   end
 
   describe "decode(string)" do
 
     it "returns nil if nil is passed in" do
-      described_class.decode(nil).should_not be
+      expect(described_class.decode(nil)).not_to be
     end
 
     it "returns nil if an empty string is passed in" do
-      described_class.decode(" ").should_not be
+      expect(described_class.decode(" ")).not_to be
     end
 
     it "decodes a string representing a date to a date" do
-      described_class.decode("20110101").should == Date.new(2011, 1, 1)
+      expect(described_class.decode("20110101")).to eq(Date.new(2011, 1, 1))
     end
 
     it "raises an argument error if the given string cannot be parsed by the date class" do
-      lambda { described_class.decode("not a date") }.should raise_error "'not a date' cannot be converted to a date"
+      expect { described_class.decode("not a date") }.to raise_error "'not a date' cannot be converted to a date"
     end
   end
 
@@ -143,34 +143,34 @@ describe XapianDb::TypeCodec::DateTimeCodec do
   describe "encode(datetime)" do
 
     it "encodes a datetime to a string with format yyyymmdd h:m:s+l" do
-      described_class.encode(DateTime.new(2011, 1, 1, 11, 30, 15)).should == "20110101 11:30:15+000"
+      expect(described_class.encode(DateTime.new(2011, 1, 1, 11, 30, 15))).to eq("20110101 11:30:15+000")
     end
 
     it "raises an argument error if the given object is not a datetime" do
-      lambda { described_class.encode("20110101") }.should raise_error "20110101 was expected to be a datetime"
+      expect { described_class.encode("20110101") }.to raise_error "20110101 was expected to be a datetime"
     end
 
     it "should return nil when a nil value is supplied" do
-      described_class.encode(nil).should_not be
+      expect(described_class.encode(nil)).not_to be
     end
   end
 
   describe "decode(string)" do
 
     it "returns nil if nil is passed in" do
-      described_class.decode(nil).should_not be
+      expect(described_class.decode(nil)).not_to be
     end
 
     it "returns nil if an empty string is passed in" do
-      described_class.decode(" ").should_not be
+      expect(described_class.decode(" ")).not_to be
     end
 
     it "decodes a string representing a date to a date" do
-      described_class.decode("20110101 11:30:15+000").should == DateTime.new(2011, 1, 1, 11, 30, 15)
+      expect(described_class.decode("20110101 11:30:15+000")).to eq(DateTime.new(2011, 1, 1, 11, 30, 15))
     end
 
     it "raises an argument error if the given string cannot be parsed by the date class" do
-      lambda { described_class.decode("not a datetime") }.should raise_error "'not a datetime' cannot be converted to a datetime"
+      expect { described_class.decode("not a datetime") }.to raise_error "'not a datetime' cannot be converted to a datetime"
     end
   end
 
@@ -181,20 +181,20 @@ describe XapianDb::TypeCodec::NumberCodec do
   describe "encode(number)" do
 
     it "encodes a number using the xapian sortable_serialise method" do
-      described_class.encode(1).should == Xapian::sortable_serialise(1)
+      expect(described_class.encode(1)).to eq(Xapian::sortable_serialise(1))
     end
 
     it "can handle big decimals" do
-      described_class.encode(BigDecimal("1")).should == Xapian::sortable_serialise(1)
+      expect(described_class.encode(BigDecimal("1"))).to eq(Xapian::sortable_serialise(1))
     end
 
     it "can handle big numbers" do
       first_bignum = 2**(0.size * 8 - 2)
-      described_class.encode(first_bignum).should == Xapian::sortable_serialise(first_bignum)
+      expect(described_class.encode(first_bignum)).to eq(Xapian::sortable_serialise(first_bignum))
     end
 
     it "raises an argument error if the given object is not a number" do
-      lambda { described_class.encode("X") }.should raise_error "X was expected to be a number"
+      expect { described_class.encode("X") }.to raise_error "X was expected to be a number"
     end
   end
 
@@ -202,11 +202,11 @@ describe XapianDb::TypeCodec::NumberCodec do
 
     it "decodes a string representing a number to a BigDecimal" do
       encoded_number = Xapian::sortable_serialise(1.5)
-      described_class.decode(encoded_number).should == BigDecimal.new("1.5")
+      expect(described_class.decode(encoded_number)).to eq(BigDecimal.new("1.5"))
     end
 
     it "raises an argument error if the argument ist not a string" do
-      lambda { described_class.decode(1) }.should raise_error "1 cannot be unserialized"
+      expect { described_class.decode(1) }.to raise_error "1 cannot be unserialized"
     end
   end
 
@@ -217,15 +217,15 @@ describe XapianDb::TypeCodec::IntegerCodec do
   describe "encode(integer)" do
 
     it "encodes an integer using the xapian sortable_serialise method" do
-      described_class.encode(1).should == Xapian::sortable_serialise(1)
+      expect(described_class.encode(1)).to eq(Xapian::sortable_serialise(1))
     end
 
     it "raises an argument error if the given object is not an integer" do
-      lambda { described_class.encode("X") }.should raise_error "X was expected to be an integer"
+      expect { described_class.encode("X") }.to raise_error "X was expected to be an integer"
     end
 
     it "should return nil when a nil value is supplied" do
-      described_class.encode(nil).should_not be
+      expect(described_class.encode(nil)).not_to be
     end
   end
 
@@ -233,15 +233,15 @@ describe XapianDb::TypeCodec::IntegerCodec do
 
     it "decodes a string representing a number to a BigDecimal" do
       encoded_number = Xapian::sortable_serialise(1)
-      described_class.decode(encoded_number).should == 1
+      expect(described_class.decode(encoded_number)).to eq(1)
     end
 
     it "returns nil if an empty string is passed in" do
-      described_class.decode(" ").should_not be
+      expect(described_class.decode(" ")).not_to be
     end
 
     it "raises an argument error if the argument ist not a string" do
-      lambda { described_class.decode(1) }.should raise_error "1 cannot be unserialized"
+      expect { described_class.decode(1) }.to raise_error "1 cannot be unserialized"
     end
   end
 

--- a/spec/xapian_db/adapters/base_adapter_spec.rb
+++ b/spec/xapian_db/adapters/base_adapter_spec.rb
@@ -12,7 +12,7 @@ describe XapianDb::Adapters::BaseAdapter do
 
     it "adds a class method to search for objects of a specific class" do
       XapianDb::Adapters::BaseAdapter.add_class_helper_methods_to PersistentObject
-      PersistentObject.should respond_to :search
+      expect(PersistentObject).to respond_to :search
     end
   end
 
@@ -65,20 +65,20 @@ describe XapianDb::Adapters::BaseAdapter do
     end
 
     it "should only find objects of a given class" do
-      XapianDb.database.search("find me").size.should == 2
+      expect(XapianDb.database.search("find me").size).to eq(2)
       result = ClassA.search("find me")
-      result.size.should == 1
-      result.first.indexed_class.should == "ClassA"
+      expect(result.size).to eq(1)
+      expect(result.first.indexed_class).to eq("ClassA")
     end
 
     it "should remove the class scope from a spelling suggestion" do
       result = ClassA.search("find mee")
-      result.spelling_suggestion.should == "find me"
+      expect(result.spelling_suggestion).to eq("find me")
     end
 
     it "should handle empty search expressions" do
-      ClassA.search(nil).size.should == 0
-      ClassA.search(" ").size.should == 0
+      expect(ClassA.search(nil).size).to eq(0)
+      expect(ClassA.search(" ").size).to eq(0)
     end
 
     context "sorting" do
@@ -96,19 +96,19 @@ describe XapianDb::Adapters::BaseAdapter do
       end
 
       it "should raise an argument error if the :order option contains an unknown attribute" do
-        lambda { ClassA.search "text", :order => :unkown }.should raise_error ArgumentError
+        expect { ClassA.search "text", :order => :unkown }.to raise_error ArgumentError
       end
 
       it "should accept an :order option" do
         result = ClassA.search "text", :order => :text
-        result.first.text.should == "A text"
-        result.last.text.should == "B text"
+        expect(result.first.text).to eq("A text")
+        expect(result.last.text).to eq("B text")
       end
 
       it "should accept an :sort_decending option" do
         result = ClassA.search "text", :order => :text, :sort_decending => true
-        result.first.text.should == "B text"
-        result.last.text.should == "A text"
+        expect(result.first.text).to eq("B text")
+        expect(result.last.text).to eq("A text")
       end
 
     end
@@ -128,7 +128,7 @@ describe XapianDb::Adapters::BaseAdapter do
         end
         indexer = XapianDb::Indexer.new XapianDb.database, XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
         obj = IndexedObject.new(1)
-        obj.stub!(:text).and_return "some text"
+        allow(obj).to receive(:text).and_return "some text"
 
         XapianDb.database.store_doc indexer.build_document_for(obj)
         XapianDb.database.commit
@@ -136,7 +136,7 @@ describe XapianDb::Adapters::BaseAdapter do
 
       it "delegates the search to the database with a class option" do
         result = IndexedObject.search "some text"
-        XapianDb.database.should_receive(:find_similar_to).with(result, :class => IndexedObject)
+        expect(XapianDb.database).to receive(:find_similar_to).with(result, :class => IndexedObject)
         IndexedObject.find_similar_to result
       end
     end
@@ -160,19 +160,19 @@ describe XapianDb::Adapters::BaseAdapter do
         db = XapianDb.database
         indexer = XapianDb::Indexer.new db, XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
         obj = IndexedObject.new(1)
-        obj.stub!(:text).and_return "Facet A"
+        allow(obj).to receive(:text).and_return "Facet A"
         db.store_doc indexer.build_document_for(obj)
         obj = IndexedObject.new(2)
-        obj.stub!(:text).and_return "Facet B"
+        allow(obj).to receive(:text).and_return "Facet B"
         db.store_doc indexer.build_document_for(obj)
         XapianDb::Adapters::BaseAdapter.add_class_helper_methods_to IndexedObject
       end
 
       it "should return a hash containing the values of the attributes and their count" do
         facets = IndexedObject.facets :text, "facet"
-        facets.size.should == 2
-        facets["Facet A"].should == 1
-        facets["Facet B"].should == 1
+        expect(facets.size).to eq(2)
+        expect(facets["Facet A"]).to eq(1)
+        expect(facets["Facet B"]).to eq(1)
       end
 
       it "scopes the facet query to the containing class" do
@@ -181,11 +181,11 @@ describe XapianDb::Adapters::BaseAdapter do
         end
         indexer = XapianDb::Indexer.new db, XapianDb::DocumentBlueprint.blueprint_for(:OtherIndexedObject)
         obj = OtherIndexedObject.new(1)
-        obj.stub!(:text).and_return "Facet C"
+        allow(obj).to receive(:text).and_return "Facet C"
         db.store_doc indexer.build_document_for(obj)
 
         facets = IndexedObject.facets :text, "facet"
-        facets.keys.should_not include("Facet C")
+        expect(facets.keys).not_to include("Facet C")
       end
 
     end

--- a/spec/xapian_db/adapters/base_adapter_spec.rb
+++ b/spec/xapian_db/adapters/base_adapter_spec.rb
@@ -145,7 +145,7 @@ describe XapianDb::Adapters::BaseAdapter do
 
       let (:db) { XapianDb.database }
 
-      before :all do
+      before :each do
 
         XapianDb.setup do |config|
           config.adapter  :generic

--- a/spec/xapian_db/adapters/datamapper_adapter_spec.rb
+++ b/spec/xapian_db/adapters/datamapper_adapter_spec.rb
@@ -25,27 +25,27 @@ describe XapianDb::Adapters::DatamapperAdapter do
   describe ".add_class_helper_methods_to(klass)" do
 
     it "adds the method 'xapian_id' to the configured class" do
-      @object.should respond_to(:xapian_id)
+      expect(@object).to respond_to(:xapian_id)
     end
 
     it "adds the method 'order_condition' to the configured class" do
-      @object.class.should respond_to(:order_condition)
+      expect(@object.class).to respond_to(:order_condition)
     end
 
     it "adds an after save hook to the configured class" do
-      DatamapperObject.hooks[:after_save].should be_a_kind_of(Proc)
+      expect(DatamapperObject.hooks[:after_save]).to be_a_kind_of(Proc)
     end
 
     it "adds an after destroy hook to the configured class" do
-      DatamapperObject.hooks[:after_destroy].should be_a_kind_of(Proc)
+      expect(DatamapperObject.hooks[:after_destroy]).to be_a_kind_of(Proc)
     end
 
     it "adds a class method to reindex all objects of a class" do
-      DatamapperObject.should respond_to(:rebuild_xapian_index)
+      expect(DatamapperObject).to respond_to(:rebuild_xapian_index)
     end
 
     it "adds the helper methods from the base class" do
-      DatamapperObject.should respond_to(:search)
+      expect(DatamapperObject).to respond_to(:search)
     end
 
   end
@@ -55,27 +55,27 @@ describe XapianDb::Adapters::DatamapperAdapter do
     it "adds the method 'id' to the object" do
       mod = Module.new
       XapianDb::Adapters::DatamapperAdapter.add_doc_helper_methods_to(mod)
-      mod.instance_methods.should include(:id)
+      expect(mod.instance_methods).to include(:id)
     end
 
     it "adds the method 'indexed_object' to the object" do
       mod = Module.new
       XapianDb::Adapters::DatamapperAdapter.add_doc_helper_methods_to(mod)
-      mod.instance_methods.should include(:indexed_object)
+      expect(mod.instance_methods).to include(:indexed_object)
     end
 
   end
 
   describe ".xapian_id" do
     it "returns a unique id composed of the class name and the id" do
-      @object.xapian_id.should == "#{@object.class}-#{@object.id}"
+      expect(@object.xapian_id).to eq("#{@object.class}-#{@object.id}")
     end
   end
 
   describe ".primary_key_for(klass)" do
 
     it "returns the name of the primary key column" do
-      XapianDb::Adapters::DatamapperAdapter.primary_key_for(DatamapperObject).should == DatamapperObject.serial.name
+      expect(XapianDb::Adapters::DatamapperAdapter.primary_key_for(DatamapperObject)).to eq(DatamapperObject.serial.name)
     end
 
   end
@@ -83,7 +83,7 @@ describe XapianDb::Adapters::DatamapperAdapter do
   describe "the after save hook" do
     it "should (re)index the object" do
       @object.save
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
     end
 
     it "should not index the object if an ignore expression in the blueprint is met" do
@@ -92,7 +92,7 @@ describe XapianDb::Adapters::DatamapperAdapter do
         blueprint.ignore_if {name == "Kogler"}
       end
       @object.save
-      XapianDb.search("Kogler").size.should == 0
+      expect(XapianDb.search("Kogler").size).to eq(0)
     end
 
     it "should index the object if an ignore expression in the blueprint is not met" do
@@ -101,7 +101,7 @@ describe XapianDb::Adapters::DatamapperAdapter do
         blueprint.ignore_if {name == "not Kogler"}
       end
       @object.save
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
     end
 
   end
@@ -109,9 +109,9 @@ describe XapianDb::Adapters::DatamapperAdapter do
   describe "the after destroy hook" do
     it "should remove the object from the index" do
       @object.save
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
       @object.destroy
-      XapianDb.search("Kogler").size.should == 0
+      expect(XapianDb.search("Kogler").size).to eq(0)
     end
   end
 
@@ -120,7 +120,7 @@ describe XapianDb::Adapters::DatamapperAdapter do
     it "should return the id of the object that is linked with the document" do
       @object.save
       doc = XapianDb.search("Kogler").first
-      doc.id.should == @object.id
+      expect(doc.id).to eq(@object.id)
     end
   end
 
@@ -129,34 +129,34 @@ describe XapianDb::Adapters::DatamapperAdapter do
     it "should return the object that is linked with the document" do
       @object.save
       doc = XapianDb.search("Kogler").first
-      doc.indexed_object.should be_equal(@object)
+      expect(doc.indexed_object).to be_equal(@object)
     end
   end
 
   describe ".rebuild_xapian_index" do
     it "should (re)index all objects of this class" do
       @object.save
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
 
       # We reopen the in memory database to destroy the index
       XapianDb.setup do |config|
         config.database :memory
       end
-      XapianDb.search("Kogler").size.should == 0
+      expect(XapianDb.search("Kogler").size).to eq(0)
 
       DatamapperObject.rebuild_xapian_index
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
     end
 
     it "should respect an ignore expression" do
       @object.save
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
 
       # We reopen the in memory database to destroy the index
       XapianDb.setup do |config|
         config.database :memory
       end
-      XapianDb.search("Kogler").size.should == 0
+      expect(XapianDb.search("Kogler").size).to eq(0)
 
       XapianDb::DocumentBlueprint.setup(:DatamapperObject) do |blueprint|
         blueprint.index :name
@@ -164,7 +164,7 @@ describe XapianDb::Adapters::DatamapperAdapter do
       end
 
       DatamapperObject.rebuild_xapian_index
-      XapianDb.search("Kogler").size.should == 0
+      expect(XapianDb.search("Kogler").size).to eq(0)
     end
 
   end

--- a/spec/xapian_db/adapters/generic_adapter_spec.rb
+++ b/spec/xapian_db/adapters/generic_adapter_spec.rb
@@ -31,7 +31,7 @@ describe XapianDb::Adapters::GenericAdapter do
 
     it "should raise an exception if the unique key is not configured" do
       XapianDb::Adapters::GenericAdapter.unique_key # undef the unique key
-      lambda{XapianDb::Adapters::GenericAdapter.add_class_helper_methods_to(MyClass)}.should raise_error
+      expect{XapianDb::Adapters::GenericAdapter.add_class_helper_methods_to(MyClass)}.to raise_error
     end
 
     it "should add the method 'xapian_id' to the configured class" do
@@ -40,12 +40,12 @@ describe XapianDb::Adapters::GenericAdapter do
       end
       XapianDb::DocumentBlueprint.setup(:MyClass)
       obj = MyClass.new(1)
-      obj.xapian_id.should == obj.my_unique_key.to_s
+      expect(obj.xapian_id).to eq(obj.my_unique_key.to_s)
     end
 
     it "adds the helper methods from the base class" do
       XapianDb::Adapters::GenericAdapter.add_class_helper_methods_to MyClass
-      MyClass.should respond_to(:search)
+      expect(MyClass).to respond_to(:search)
     end
 
   end

--- a/spec/xapian_db/adapters/generic_adapter_spec.rb
+++ b/spec/xapian_db/adapters/generic_adapter_spec.rb
@@ -31,7 +31,7 @@ describe XapianDb::Adapters::GenericAdapter do
 
     it "should raise an exception if the unique key is not configured" do
       XapianDb::Adapters::GenericAdapter.unique_key # undef the unique key
-      expect{XapianDb::Adapters::GenericAdapter.add_class_helper_methods_to(MyClass)}.to raise_error
+      expect{XapianDb::Adapters::GenericAdapter.add_class_helper_methods_to(MyClass)}.to raise_error "Unique key is not configured for generic adapter!"
     end
 
     it "should add the method 'xapian_id' to the configured class" do

--- a/spec/xapian_db/config_spec.rb
+++ b/spec/xapian_db/config_spec.rb
@@ -10,7 +10,7 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.database :memory
         end
-        XapianDb.database.should be_a_kind_of XapianDb::InMemoryDatabase
+        expect(XapianDb.database).to be_a_kind_of XapianDb::InMemoryDatabase
       end
 
       it "accepts a persistent database" do
@@ -18,8 +18,8 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.database db_path
         end
-        File.exist?(db_path).should be_true
-        XapianDb.database.should be_a_kind_of XapianDb::PersistentDatabase
+        expect(File.exist?(db_path)).to be_truthy
+        expect(XapianDb.database).to be_a_kind_of XapianDb::PersistentDatabase
         FileUtils.rm_rf db_path
       end
 
@@ -27,12 +27,12 @@ describe XapianDb::Config do
         db_path = "/tmp/xapian_db"
         FileUtils.rm_rf db_path
 
-        XapianDb.should_receive :create_db
+        expect(XapianDb).to receive :create_db
         XapianDb::Config.setup do |config|
           config.database db_path
         end
 
-        XapianDb.should_receive :open_db
+        expect(XapianDb).to receive :open_db
         XapianDb::Config.setup do |config|
           config.database db_path
         end
@@ -56,27 +56,27 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.adapter :generic
         end
-        XapianDb::Config.adapter.should be_equal XapianDb::Adapters::GenericAdapter
+        expect(XapianDb::Config.adapter).to be_equal XapianDb::Adapters::GenericAdapter
       end
 
       it "accepts a datamapper adapter" do
         XapianDb::Config.setup do |config|
           config.adapter :datamapper
         end
-        XapianDb::Config.adapter.should be_equal XapianDb::Adapters::DatamapperAdapter
+        expect(XapianDb::Config.adapter).to be_equal XapianDb::Adapters::DatamapperAdapter
       end
 
       it "accepts an active_record adapter" do
         XapianDb::Config.setup do |config|
           config.adapter :active_record
         end
-        XapianDb::Config.adapter.should be_equal XapianDb::Adapters::ActiveRecordAdapter
+        expect(XapianDb::Config.adapter).to be_equal XapianDb::Adapters::ActiveRecordAdapter
       end
 
       it "raises an error if the configured adapter is unknown" do
-        lambda{XapianDb::Config.setup do |config|
+        expect{XapianDb::Config.setup do |config|
           config.adapter :unknown
-        end}.should raise_error
+        end}.to raise_error
       end
     end
 
@@ -85,7 +85,7 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.writer :direct
         end
-        XapianDb::Config.writer.should be_equal XapianDb::IndexWriters::DirectWriter
+        expect(XapianDb::Config.writer).to be_equal XapianDb::IndexWriters::DirectWriter
       end
 
       it "accepts the beanstalk writer, if the beanstalk-client gem is installed" do
@@ -93,7 +93,7 @@ describe XapianDb::Config do
           XapianDb::Config.setup do |config|
             config.writer :beanstalk
           end
-          XapianDb::Config.writer.should be_equal XapianDb::IndexWriters::BeanstalkWriter
+          expect(XapianDb::Config.writer).to be_equal XapianDb::IndexWriters::BeanstalkWriter
         else
           pending "cannot run this spec without the beanstalk-client gem installed"
         end
@@ -104,7 +104,7 @@ describe XapianDb::Config do
           XapianDb::Config.setup do |config|
             config.writer :resque
           end
-          XapianDb::Config.writer.should == XapianDb::IndexWriters::ResqueWriter
+          expect(XapianDb::Config.writer).to eq(XapianDb::IndexWriters::ResqueWriter)
         else
           pending "cannot run this spec without the resque gem installed"
         end
@@ -115,44 +115,44 @@ describe XapianDb::Config do
           XapianDb::Config.setup do |config|
             config.writer :sidekiq
           end
-          XapianDb::Config.writer.should == XapianDb::IndexWriters::SidekiqWriter
+          expect(XapianDb::Config.writer).to eq(XapianDb::IndexWriters::SidekiqWriter)
         else
           pending "cannot run this spec without the sidekiq gem installed"
         end
       end
 
       it "raises an error if the configured writer is unknown" do
-        lambda{XapianDb::Config.setup do |config|
+        expect{XapianDb::Config.setup do |config|
           config.writer :unknown
-        end}.should raise_error
+        end}.to raise_error
       end
 
     end
 
     describe ".beanstalk_daemon" do
       it "defaults to localhost:11300" do
-        XapianDb::Config.beanstalk_daemon_url.should == "localhost:11300"
+        expect(XapianDb::Config.beanstalk_daemon_url).to eq("localhost:11300")
       end
 
       it "accepts an url" do
         XapianDb::Config.setup do |config|
           config.beanstalk_daemon_url "localhost:9000"
         end
-        XapianDb::Config.beanstalk_daemon_url.should == "localhost:9000"
+        expect(XapianDb::Config.beanstalk_daemon_url).to eq("localhost:9000")
       end
 
     end
 
     describe ".resque_queue" do
       it "returns 'xapian_db' by default" do
-        XapianDb::Config.resque_queue.should == 'xapian_db'
+        expect(XapianDb::Config.resque_queue).to eq('xapian_db')
       end
 
       it "accepts a name" do
         XapianDb::Config.setup do |config|
           config.resque_queue 'my_queue'
         end
-        XapianDb::Config.resque_queue.should == 'my_queue'
+        expect(XapianDb::Config.resque_queue).to eq('my_queue')
       end
     end
 
@@ -162,30 +162,30 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.language :de
         end
-        XapianDb::Config.stemmer.should be_a_kind_of Xapian::Stem
-        XapianDb::Config.stopper.should be_a_kind_of Xapian::SimpleStopper
+        expect(XapianDb::Config.stemmer).to be_a_kind_of Xapian::Stem
+        expect(XapianDb::Config.stopper).to be_a_kind_of Xapian::SimpleStopper
       end
 
       it "does not create a stopper for the argument :none" do
         XapianDb::Config.setup do |config|
           config.language :none
         end
-        XapianDb::Config.stemmer.should be_a_kind_of Xapian::Stem
-        XapianDb::Config.stopper.should_not be
+        expect(XapianDb::Config.stemmer).to be_a_kind_of Xapian::Stem
+        expect(XapianDb::Config.stopper).not_to be
       end
 
       it "raises an invalid argument error if an unsupported language is applied" do
-        lambda{XapianDb::Config.setup do |config|
+        expect{XapianDb::Config.setup do |config|
           config.language :not_supported
-        end}.should raise_error ArgumentError
+        end}.to raise_error ArgumentError
       end
 
       it "can handle nil as an argument" do
         XapianDb::Config.setup do |config|
           config.language nil
         end
-        XapianDb::Config.stemmer.should be_a_kind_of Xapian::Stem
-        XapianDb::Config.stopper.should_not be
+        expect(XapianDb::Config.stemmer).to be_a_kind_of Xapian::Stem
+        expect(XapianDb::Config.stopper).not_to be
       end
 
     end
@@ -195,7 +195,7 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.term_min_length 2
         end
-        XapianDb::Config.term_min_length.should == 2
+        expect(XapianDb::Config.term_min_length).to eq(2)
       end
     end
 
@@ -204,11 +204,11 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.term_splitter_count 3
         end
-        XapianDb::Config.term_splitter_count.should == 3
+        expect(XapianDb::Config.term_splitter_count).to eq(3)
       end
 
       it "defaults to 0" do
-        XapianDb::Config.term_splitter_count.should == 0
+        expect(XapianDb::Config.term_splitter_count).to eq(0)
       end
     end
 
@@ -217,7 +217,7 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.enable_query_flag Xapian::QueryParser::FLAG_PHRASE
         end
-        XapianDb::Config.query_flags.should include(Xapian::QueryParser::FLAG_PHRASE)
+        expect(XapianDb::Config.query_flags).to include(Xapian::QueryParser::FLAG_PHRASE)
       end
     end
 
@@ -227,7 +227,7 @@ describe XapianDb::Config do
         XapianDb::Config.setup do |config|
           config.disable_query_flag Xapian::QueryParser::FLAG_WILDCARD
         end
-        XapianDb::Config.query_flags.should_not include(Xapian::QueryParser::FLAG_WILDCARD)
+        expect(XapianDb::Config.query_flags).not_to include(Xapian::QueryParser::FLAG_WILDCARD)
       end
     end
 

--- a/spec/xapian_db/config_spec.rb
+++ b/spec/xapian_db/config_spec.rb
@@ -76,7 +76,7 @@ describe XapianDb::Config do
       it "raises an error if the configured adapter is unknown" do
         expect{XapianDb::Config.setup do |config|
           config.adapter :unknown
-        end}.to raise_error
+        end}.to raise_error LoadError
       end
     end
 
@@ -124,7 +124,7 @@ describe XapianDb::Config do
       it "raises an error if the configured writer is unknown" do
         expect{XapianDb::Config.setup do |config|
           config.writer :unknown
-        end}.to raise_error
+        end}.to raise_error LoadError
       end
 
     end

--- a/spec/xapian_db/config_spec.rb
+++ b/spec/xapian_db/config_spec.rb
@@ -231,5 +231,22 @@ describe XapianDb::Config do
       end
     end
 
+    describe ".indexer_preprocess_callback" do
+      it "sets the indexer preprocess callback method" do
+        class Klass
+          def self.normalize(text) end
+        end
+        XapianDb::Config.setup do |config|
+          config.indexer_preprocess_callback Klass.method(:normalize)
+        end
+
+        expect(XapianDb::Config.preprocess_terms).to be_a_kind_of Method
+
+        XapianDb::Config.setup do |config|
+          config.indexer_preprocess_callback nil
+        end
+      end
+    end
+
   end
 end

--- a/spec/xapian_db/database_spec.rb
+++ b/spec/xapian_db/database_spec.rb
@@ -18,21 +18,21 @@ describe XapianDb::Database do
       @blueprint = XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
       @indexer   = XapianDb::Indexer.new(XapianDb.database, @blueprint)
       @obj       = IndexedObject.new(1)
-      @obj.stub!(:text).and_return("Some Text")
+      allow(@obj).to receive(:text).and_return("Some Text")
       @doc       = @indexer.build_document_for(@obj)
     end
 
     it "should store the document in the database" do
-      XapianDb.database.store_doc(@doc).should be_true
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
       XapianDb.database.commit
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
     it "must replace a document if the object is already indexed" do
-      XapianDb.database.store_doc(@doc).should be_true
-      XapianDb.database.store_doc(@doc).should be_true
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
       XapianDb.database.commit
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
   end
@@ -51,17 +51,17 @@ describe XapianDb::Database do
       @blueprint = XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
       @indexer   = XapianDb::Indexer.new(XapianDb.database, @blueprint)
       @obj       = IndexedObject.new(1)
-      @obj.stub!(:text).and_return("Some Text")
+      allow(@obj).to receive(:text).and_return("Some Text")
       @doc       = @indexer.build_document_for(@obj)
     end
 
     it "should delete the document with this term in the database" do
-      XapianDb.database.store_doc(@doc).should be_true
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
       XapianDb.database.commit
-      XapianDb.database.size.should == 1
-      XapianDb.database.delete_doc_with_unique_term(@doc.data).should be_true
+      expect(XapianDb.database.size).to eq(1)
+      expect(XapianDb.database.delete_doc_with_unique_term(@doc.data)).to be_truthy
       XapianDb.database.commit
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
     end
 
   end
@@ -85,17 +85,17 @@ describe XapianDb::Database do
       # Create two test objects we will delete later
       obj = IndexedObject.new(1)
       doc = @indexer.build_document_for(obj)
-      XapianDb.database.store_doc(doc).should be_true
+      expect(XapianDb.database.store_doc(doc)).to be_truthy
       obj = IndexedObject.new(2)
       doc = @indexer.build_document_for(obj)
-      XapianDb.database.store_doc(doc).should be_true
+      expect(XapianDb.database.store_doc(doc)).to be_truthy
       XapianDb.database.commit
-      XapianDb.database.size.should == 2
+      expect(XapianDb.database.size).to eq(2)
 
       # Now delete all docs of IndexedObject
       XapianDb.database.delete_docs_of_class(IndexedObject)
       XapianDb.database.commit
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
 
     end
 
@@ -117,23 +117,23 @@ describe XapianDb::Database do
       # Create two test objects we will delete later
       obj = IndexedObject.new(1)
       doc = @indexer.build_document_for(obj)
-      XapianDb.database.store_doc(doc).should be_true
+      expect(XapianDb.database.store_doc(doc)).to be_truthy
       obj = IndexedObject.new(2)
       doc = @indexer.build_document_for(obj)
-      XapianDb.database.store_doc(doc).should be_true
+      expect(XapianDb.database.store_doc(doc)).to be_truthy
 
       # Now create an object of a different class that has a term "IndexedObject"
       leave_me_alone = LeaveMeAlone.new(1, "IndexedObject")
       doc = @indexer.build_document_for(leave_me_alone)
-      XapianDb.database.store_doc(doc).should be_true
+      expect(XapianDb.database.store_doc(doc)).to be_truthy
 
       XapianDb.database.commit
-      XapianDb.database.size.should == 3
+      expect(XapianDb.database.size).to eq(3)
 
       # Now delete all docs of IndexedObject
       XapianDb.database.delete_docs_of_class(IndexedObject)
       XapianDb.database.commit
-      XapianDb.database.size.should == 1 # leave_me_alone must still exist
+      expect(XapianDb.database.size).to eq(1) # leave_me_alone must still exist
 
     end
 
@@ -149,7 +149,7 @@ describe XapianDb::Database do
     end
 
     it "must be 0 for a new database" do
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
     end
 
   end
@@ -168,45 +168,45 @@ describe XapianDb::Database do
       @blueprint = XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
       @indexer   = XapianDb::Indexer.new(XapianDb.database, @blueprint)
       @obj       = IndexedObject.new(1)
-      @obj.stub!(:text).and_return("Some Text")
-      @obj.stub!(:text2).and_return("findme_in_text2")
+      allow(@obj).to receive(:text).and_return("Some Text")
+      allow(@obj).to receive(:text2).and_return("findme_in_text2")
       @doc       = @indexer.build_document_for(@obj)
     end
 
     it "should return an empty resultset for nil as the search argument" do
-      XapianDb.database.store_doc(@doc).should be_true
-      XapianDb.database.search(nil).size.should == 0
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
+      expect(XapianDb.database.search(nil).size).to eq(0)
     end
 
     it "should return an empty resultset for an empty string as the search argument" do
-      XapianDb.database.store_doc(@doc).should be_true
-      XapianDb.database.search(" ").size.should == 0
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
+      expect(XapianDb.database.search(" ").size).to eq(0)
     end
 
     it "should find a stored document" do
-      XapianDb.database.store_doc(@doc).should be_true
-      XapianDb.database.search("Some").size.should == 1
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
+      expect(XapianDb.database.search("Some").size).to eq(1)
     end
 
     it "should find a stored document with a wildcard expression" do
-      XapianDb.database.store_doc(@doc).should be_true
-      XapianDb.database.search("Som*").size.should == 1
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
+      expect(XapianDb.database.search("Som*").size).to eq(1)
     end
 
     it "should find a stored document with a field expression" do
-      XapianDb.database.store_doc(@doc).should be_true
-      XapianDb.database.search("text:findme_in_text2").size.should == 0
-      XapianDb.database.search("text2:findme_in_text2").size.should == 1
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
+      expect(XapianDb.database.search("text:findme_in_text2").size).to eq(0)
+      expect(XapianDb.database.search("text2:findme_in_text2").size).to eq(1)
     end
 
     it "should retry if a Xapian::DatabaseModifiedError occurs" do
-      XapianDb.database.store_doc(@doc).should be_true
+      expect(XapianDb.database.store_doc(@doc)).to be_truthy
 
       # first try
-      XapianDb::Resultset.should_receive(:new).and_raise IOError.new "DatabaseModifiedError: The revision being read has been discarded - you should call Xapian::Database::reopen() and retry the operation"
+      expect(XapianDb::Resultset).to receive(:new).and_raise IOError.new "DatabaseModifiedError: The revision being read has been discarded - you should call Xapian::Database::reopen() and retry the operation"
       # second try
-      XapianDb::Resultset.should_receive(:new).and_return [1]
-      XapianDb.database.search("text2:findme_in_text2").size.should == 1
+      expect(XapianDb::Resultset).to receive(:new).and_return [1]
+      expect(XapianDb.database.search("text2:findme_in_text2").size).to eq(1)
     end
 
     it "should support phrase searches" do
@@ -218,17 +218,17 @@ describe XapianDb::Database do
         blueprint.index :text
       end
       obj       = IndexedObject.new(1)
-      obj.stub!(:text).and_return("This is a complete sentence")
+      allow(obj).to receive(:text).and_return("This is a complete sentence")
       doc       = @indexer.build_document_for(obj)
-      XapianDb.database.store_doc(doc).should be_true
+      expect(XapianDb.database.store_doc(doc)).to be_truthy
 
       obj       = IndexedObject.new(2)
-      obj.stub!(:text).and_return("This sentence is a complete one")
+      allow(obj).to receive(:text).and_return("This sentence is a complete one")
       doc       = @indexer.build_document_for(obj)
-      XapianDb.database.store_doc(doc).should be_true
+      expect(XapianDb.database.store_doc(doc)).to be_truthy
 
-      XapianDb.database.search('This is a complete sentence').size.should == 2
-      XapianDb.database.search('"This is a complete sentence"').size.should == 1
+      expect(XapianDb.database.search('This is a complete sentence').size).to eq(2)
+      expect(XapianDb.database.search('"This is a complete sentence"').size).to eq(1)
     end
 
     describe "spelling correction" do
@@ -249,22 +249,22 @@ describe XapianDb::Database do
       end
 
       it "should provide a spelling correction if a language is configured" do
-        @obj.stub!(:text).and_return("Hallo Nachbar")
+        allow(@obj).to receive(:text).and_return("Hallo Nachbar")
         @doc     = @indexer.build_document_for(@obj)
-        db.store_doc(@doc).should be_true
+        expect(db.store_doc(@doc)).to be_truthy
         db.commit
-        db.size.should == 1
+        expect(db.size).to eq(1)
         result = db.search "Halo Naachbar"
-        result.spelling_suggestion.should == "hallo nachbar"
+        expect(result.spelling_suggestion).to eq("hallo nachbar")
       end
 
       it "should provide correction with the right encoding" do
-        @obj.stub!(:text).and_return("Tschüs")
+        allow(@obj).to receive(:text).and_return("Tschüs")
         @doc = @indexer.build_document_for(@obj)
         db.store_doc(@doc)
         db.commit
         result = db.search "stchüs"
-        result.spelling_suggestion.should == "tschüs"
+        expect(result.spelling_suggestion).to eq("tschüs")
       end
     end
 
@@ -278,15 +278,15 @@ describe XapianDb::Database do
         end
 
         obj = IndexedObject.new(1)
-        obj.stub!(:text).and_return("same_sort")
-        obj.stub!(:text2).and_return("B text")
-        obj.stub!(:number).and_return(10)
+        allow(obj).to receive(:text).and_return("same_sort")
+        allow(obj).to receive(:text2).and_return("B text")
+        allow(obj).to receive(:number).and_return(10)
         doc = @indexer.build_document_for(obj)
         XapianDb.database.store_doc doc
         obj = IndexedObject.new(2)
-        obj.stub!(:text).and_return("same_sort")
-        obj.stub!(:text2).and_return("A text")
-        obj.stub!(:number).and_return(1)
+        allow(obj).to receive(:text).and_return("same_sort")
+        allow(obj).to receive(:text2).and_return("A text")
+        allow(obj).to receive(:number).and_return(1)
         doc = @indexer.build_document_for(obj)
         XapianDb.database.store_doc doc
       end
@@ -297,7 +297,7 @@ describe XapianDb::Database do
 
           it "sorts the result by relevance, then id" do
             result = XapianDb.database.search "same_sort"
-            result.map { |doc| doc.data.split("-").last.to_i }.should == [1, 2]
+            expect(result.map { |doc| doc.data.split("-").last.to_i }).to eq([1, 2])
           end
 
         end
@@ -311,18 +311,18 @@ describe XapianDb::Database do
             end
 
             obj = IndexedObject.new(1)
-            obj.stub!(:text).and_return("Text B")
+            allow(obj).to receive(:text).and_return("Text B")
             doc = @indexer.build_document_for(obj)
             XapianDb.database.store_doc doc
             obj = IndexedObject.new(2)
-            obj.stub!(:text).and_return("Text A")
+            allow(obj).to receive(:text).and_return("Text A")
             doc = @indexer.build_document_for(obj)
             XapianDb.database.store_doc doc
           end
 
           it "sorts the result by relevance, then natural sort" do
             result = XapianDb.database.search "Text"
-            result.map { |doc| doc.data.split("-").last.to_i }.should == [2, 1]
+            expect(result.map { |doc| doc.data.split("-").last.to_i }).to eq([2, 1])
           end
         end
       end
@@ -330,65 +330,65 @@ describe XapianDb::Database do
       it "accepts the :sort_indices option for a query" do
         sort_indices = [XapianDb::DocumentBlueprint.value_number_for(:text2)]
         result = XapianDb.database.search "text", :sort_indices => sort_indices
-        result.size.should == 2
-        result.first.text2.should == "A text"
-        result.last.text2.should == "B text"
+        expect(result.size).to eq(2)
+        expect(result.first.text2).to eq("A text")
+        expect(result.last.text2).to eq("B text")
       end
 
       it "accepts the :sort_indices option for a query that is scoped to a class" do
         sort_indices = [XapianDb::DocumentBlueprint.value_number_for(:text2)]
         result = XapianDb.database.search "indexed_class:indexedobject and text", :sort_indices => sort_indices
-        result.size.should == 2
-        result.first.text2.should == "A text"
-        result.last.text2.should == "B text"
+        expect(result.size).to eq(2)
+        expect(result.first.text2).to eq("A text")
+        expect(result.last.text2).to eq("B text")
       end
 
       it "accepts the :sort_decending option for a query" do
         sort_indices = [XapianDb::DocumentBlueprint.value_number_for(:text)]
         result = XapianDb.database.search "text", :sort_indices => sort_indices, :sort_decending => true
-        result.size.should == 2
-        result.first.text2.should == "B text"
-        result.last.text2.should == "A text"
+        expect(result.size).to eq(2)
+        expect(result.first.text2).to eq("B text")
+        expect(result.last.text2).to eq("A text")
       end
 
       it "accepts the :sort_decending option for a query that is scoped to a class" do
         sort_indices = [XapianDb::DocumentBlueprint.value_number_for(:text)]
         result = XapianDb.database.search "indexed_class:indexedobject and text", :sort_indices => sort_indices, :sort_decending => true
-        result.size.should == 2
-        result.first.text2.should == "B text"
-        result.last.text2.should == "A text"
+        expect(result.size).to eq(2)
+        expect(result.first.text2).to eq("B text")
+        expect(result.last.text2).to eq("A text")
       end
 
       it "accepts multiple indices for the :sort_indices option" do
         sort_indices = [XapianDb::DocumentBlueprint.value_number_for(:text), XapianDb::DocumentBlueprint.value_number_for(:text2)]
         result = XapianDb.database.search "text", :sort_indices => sort_indices
-        result.size.should == 2
-        result.first.text2.should == "A text"
-        result.last.text2.should == "B text"
+        expect(result.size).to eq(2)
+        expect(result.first.text2).to eq("A text")
+        expect(result.last.text2).to eq("B text")
       end
 
       it "accepts multiple indices for the :sort_indices option for a query that is scoped to a class" do
         sort_indices = [XapianDb::DocumentBlueprint.value_number_for(:text), XapianDb::DocumentBlueprint.value_number_for(:text2)]
         result = XapianDb.database.search "indexed_class:indexedobject and text", :sort_indices => sort_indices
-        result.size.should == 2
-        result.first.text2.should == "A text"
-        result.last.text2.should == "B text"
+        expect(result.size).to eq(2)
+        expect(result.first.text2).to eq("A text")
+        expect(result.last.text2).to eq("B text")
       end
 
       it "orders the result numerically if a number attribute is used for sorting" do
         sort_indices = [XapianDb::DocumentBlueprint.value_number_for(:number)]
         result = XapianDb.database.search "text", :sort_indices => sort_indices
-        result.size.should == 2
-        result.first.number.should == 1
-        result.last.number.should == 10
+        expect(result.size).to eq(2)
+        expect(result.first.number).to eq(1)
+        expect(result.last.number).to eq(10)
       end
 
       it "accepts the :order option for a query" do
         # sort_indices = [XapianDb::DocumentBlueprint.value_number_for(:text2)]
         result = XapianDb.database.search "text", order: [:text2]
-        result.size.should == 2
-        result.first.text2.should == "A text"
-        result.last.text2.should == "B text"
+        expect(result.size).to eq(2)
+        expect(result.first.text2).to eq("A text")
+        expect(result.last.text2).to eq("B text")
       end
 
       it "raises an argument error if sort_indices and order are both used" do
@@ -416,19 +416,19 @@ describe XapianDb::Database do
 
       indexer = XapianDb::Indexer.new db, XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
       obj = IndexedObject.new(1)
-      obj.stub!(:text).and_return "Facet A"
+      allow(obj).to receive(:text).and_return "Facet A"
       db.store_doc indexer.build_document_for(obj)
       obj = IndexedObject.new(2)
-      obj.stub!(:text).and_return "Facet B"
+      allow(obj).to receive(:text).and_return "Facet B"
       db.store_doc indexer.build_document_for(obj)
       XapianDb::Adapters::BaseAdapter.add_class_helper_methods_to IndexedObject
     end
 
     it "should return a hash containing the values of the attributes and their count" do
       facets = XapianDb.database.facets :text, "facet"
-      facets.size.should == 2
-      facets["Facet A"].should == 1
-      facets["Facet B"].should == 1
+      expect(facets.size).to eq(2)
+      expect(facets["Facet A"]).to eq(1)
+      expect(facets["Facet B"]).to eq(1)
     end
 
     it "collects the facets across all indexed classes" do
@@ -437,14 +437,14 @@ describe XapianDb::Database do
       end
       indexer = XapianDb::Indexer.new db, XapianDb::DocumentBlueprint.blueprint_for(:OtherIndexedObject)
       obj = OtherIndexedObject.new(1)
-      obj.stub!(:text).and_return "Facet C"
+      allow(obj).to receive(:text).and_return "Facet C"
       db.store_doc indexer.build_document_for(obj)
 
       facets = XapianDb.database.facets :text, "facet"
-      facets.size.should == 3
-      facets["Facet A"].should == 1
-      facets["Facet B"].should == 1
-      facets["Facet C"].should == 1
+      expect(facets.size).to eq(3)
+      expect(facets["Facet A"]).to eq(1)
+      expect(facets["Facet B"]).to eq(1)
+      expect(facets["Facet C"]).to eq(1)
 
     end
 
@@ -486,23 +486,23 @@ describe XapianDb::Database do
 
     it "accepts a single xapian document" do
       reference = XapianDb.database.search "xapian rocks"
-      lambda { XapianDb.database.find_similar_to reference.first }.should_not raise_error
+      expect { XapianDb.database.find_similar_to reference.first }.not_to raise_error
     end
 
     it "accepts a resultset" do
       reference = XapianDb.database.search "xapian"
-      lambda { XapianDb.database.find_similar_to reference }.should_not raise_error
+      expect { XapianDb.database.find_similar_to reference }.not_to raise_error
     end
 
     it "returns a resultset" do
       reference = XapianDb.database.search "xapian"
-      XapianDb.database.find_similar_to(reference).should be_a XapianDb::Resultset
+      expect(XapianDb.database.find_similar_to(reference)).to be_a XapianDb::Resultset
     end
 
     it "does not return the reference document(s)" do
       reference = XapianDb.database.search "xapian rocks"
       result = XapianDb.database.find_similar_to(reference)
-      result.detect {|doc| doc.docid == reference.first.docid}.should_not be
+      expect(result.detect {|doc| doc.docid == reference.first.docid}).not_to be
     end
 
     describe "with a class option" do
@@ -530,7 +530,7 @@ describe XapianDb::Database do
       it "should not find documents based on other classes" do
         reference = XapianDb.database.search "xapian rocks"
         result = XapianDb.database.find_similar_to(reference, :class => Class)
-        result.detect { |doc| doc.indexed_class != Class.name }.should_not be
+        expect(result.detect { |doc| doc.indexed_class != Class.name }).not_to be
       end
 
     end
@@ -540,7 +540,7 @@ describe XapianDb::Database do
       it "respects the limit" do
         reference = XapianDb.database.search "xapian rocks"
         result = XapianDb.database.find_similar_to reference, :limit => 1
-        result.size.should == 1
+        expect(result.size).to eq(1)
       end
 
     end
@@ -562,7 +562,7 @@ describe XapianDb::InMemoryDatabase do
       doc = Xapian::Document.new
       doc.data = "1" # We need data to store the doc
       XapianDb.database.store_doc(doc)
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
   end
@@ -585,7 +585,7 @@ describe XapianDb::PersistentDatabase do
     doc = Xapian::Document.new
     doc.data = "1" # We need data to store the doc
     XapianDb.database.store_doc(doc)
-    XapianDb.database.size.should == 0
+    expect(XapianDb.database.size).to eq(0)
   end
 
   describe "#commit" do
@@ -594,9 +594,9 @@ describe XapianDb::PersistentDatabase do
       doc = Xapian::Document.new
       doc.data = "1" # We need data to store the doc
       XapianDb.database.store_doc(doc)
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       XapianDb.database.commit
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
   end

--- a/spec/xapian_db/database_spec.rb
+++ b/spec/xapian_db/database_spec.rb
@@ -403,7 +403,7 @@ describe XapianDb::Database do
 
     let (:db) { XapianDb.database }
 
-    before :all do
+    before :each do
       XapianDb.setup do |config|
         config.adapter  :generic
         config.database :memory

--- a/spec/xapian_db/document_blueprint_spec.rb
+++ b/spec/xapian_db/document_blueprint_spec.rb
@@ -13,7 +13,7 @@ describe XapianDb::DocumentBlueprint do
       end
       XapianDb::DocumentBlueprint.reset
 
-      XapianDb::DocumentBlueprint.configured_classes.should == []
+      expect(XapianDb::DocumentBlueprint.configured_classes).to eq([])
     end
   end
 
@@ -21,13 +21,13 @@ describe XapianDb::DocumentBlueprint do
 
     it "returns all configured classes" do
       XapianDb::DocumentBlueprint.reset
-      XapianDb::DocumentBlueprint.configured_classes.size.should == 0
+      expect(XapianDb::DocumentBlueprint.configured_classes.size).to eq(0)
 
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.configured_classes.should == [IndexedObject]
+      expect(XapianDb::DocumentBlueprint.configured_classes).to eq([IndexedObject])
     end
   end
 
@@ -42,11 +42,11 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.configured?(:IndexedObject).should be_true
+      expect(XapianDb::DocumentBlueprint.configured?(:IndexedObject)).to be_truthy
     end
 
     it "returns false, if no blueprints are configured" do
-      XapianDb::DocumentBlueprint.configured?(:IndexedObject).should be_false
+      expect(XapianDb::DocumentBlueprint.configured?(:IndexedObject)).to be_falsey
     end
 
     it "returns false, if a blueprint with the given name is not configured" do
@@ -54,7 +54,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.configured?(:NotConfigured).should be_false
+      expect(XapianDb::DocumentBlueprint.configured?(:NotConfigured)).to be_falsey
     end
   end
 
@@ -69,7 +69,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).should be_a_kind_of XapianDb::DocumentBlueprint
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)).to be_a_kind_of XapianDb::DocumentBlueprint
     end
 
     it "returns the blueprint for the super class if no specific blueprint is configured" do
@@ -78,7 +78,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :name
       end
       class InheritedIndexedObject < IndexedObject; end
-      XapianDb::DocumentBlueprint.blueprint_for(:InheritedIndexedObject).should == XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:InheritedIndexedObject)).to eq(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject))
     end
 
     it "can handle namespaces" do
@@ -86,15 +86,15 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for("Namespace::IndexedObject").should be_a_kind_of XapianDb::DocumentBlueprint
+      expect(XapianDb::DocumentBlueprint.blueprint_for("Namespace::IndexedObject")).to be_a_kind_of XapianDb::DocumentBlueprint
     end
 
     it "returns nil if there is no blueprint configuration for a class" do
-      XapianDb::DocumentBlueprint.blueprint_for(:Object).should_not be
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:Object)).not_to be
     end
 
     it "returns nil if there is no blueprint configuration at all" do
-      XapianDb::DocumentBlueprint.blueprint_for(:Object).should_not be
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:Object)).not_to be
     end
 
     it "accepts a string for the class name" do
@@ -102,7 +102,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for("IndexedObject").should be_a_kind_of XapianDb::DocumentBlueprint
+      expect(XapianDb::DocumentBlueprint.blueprint_for("IndexedObject")).to be_a_kind_of XapianDb::DocumentBlueprint
     end
 
     it "accepts a symbol for the class name" do
@@ -110,7 +110,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).should be_a_kind_of XapianDb::DocumentBlueprint
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)).to be_a_kind_of XapianDb::DocumentBlueprint
     end
   end
 
@@ -130,7 +130,7 @@ describe XapianDb::DocumentBlueprint do
         end
       end
 
-      expect(XapianDb::DocumentBlueprint.dependencies_for 'IndexedObject', []).to have(1).item
+      expect(XapianDb::DocumentBlueprint.dependencies_for('IndexedObject', []).size).to eq(1)
     end
 
     it "returns dependency objects that match the klass name and the attributes they're interested in, when specified" do
@@ -148,7 +148,7 @@ describe XapianDb::DocumentBlueprint do
       end
 
       expect(XapianDb::DocumentBlueprint.dependencies_for 'IndexedObject', []).to be_empty # no change for name
-      expect(XapianDb::DocumentBlueprint.dependencies_for 'IndexedObject', ['name']).to have(1).item
+      expect(XapianDb::DocumentBlueprint.dependencies_for('IndexedObject', ['name']).size).to eq(1)
     end
   end
 
@@ -159,14 +159,14 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.searchable_prefixes.should include(:id, :name)
+      expect(XapianDb::DocumentBlueprint.searchable_prefixes).to include(:id, :name)
     end
 
     it "should return %w(indexed_class) if no attributes and no indexes are configured" do
       XapianDb::DocumentBlueprint.reset
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
       end
-      XapianDb::DocumentBlueprint.searchable_prefixes.should == %w(indexed_class)
+      expect(XapianDb::DocumentBlueprint.searchable_prefixes).to eq(%w(indexed_class))
     end
   end
 
@@ -177,7 +177,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.attribute :id
         blueprint.attribute :name
       end
-      XapianDb::DocumentBlueprint.attributes.should include(:id, :name)
+      expect(XapianDb::DocumentBlueprint.attributes).to include(:id, :name)
     end
 
     it "should return an empty array if no attributes are configured" do
@@ -186,7 +186,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :id
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.attributes.should == []
+      expect(XapianDb::DocumentBlueprint.attributes).to eq([])
     end
   end
 
@@ -200,64 +200,64 @@ describe XapianDb::DocumentBlueprint do
     end
 
     it "should return the type of an attribute if one is defined" do
-      XapianDb::DocumentBlueprint.type_info_for(:date).should == :date
+      expect(XapianDb::DocumentBlueprint.type_info_for(:date)).to eq(:date)
     end
 
     it "should return :string if no type is defined" do
-      XapianDb::DocumentBlueprint.type_info_for(:untyped).should == :string
+      expect(XapianDb::DocumentBlueprint.type_info_for(:untyped)).to eq(:string)
     end
 
     it "returns nil if the attribute is not defined" do
-      XapianDb::DocumentBlueprint.type_info_for(:not_defined).should_not be
+      expect(XapianDb::DocumentBlueprint.type_info_for(:not_defined)).not_to be
     end
 
     it "returns nil if no blueprints are defined defined" do
       XapianDb::DocumentBlueprint.reset
-      XapianDb::DocumentBlueprint.type_info_for(:not_defined).should_not be
+      expect(XapianDb::DocumentBlueprint.type_info_for(:not_defined)).not_to be
     end
   end
 
   describe ".setup (class)" do
     it "stores a blueprint for a given class" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject)
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).should be_a_kind_of(XapianDb::DocumentBlueprint)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)).to be_a_kind_of(XapianDb::DocumentBlueprint)
     end
 
     it "does replace the blueprint for a class if the class is reloaded" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject)
-      XapianDb::DocumentBlueprint.configured_classes.size.should == 1
+      expect(XapianDb::DocumentBlueprint.configured_classes.size).to eq(1)
       # reload IndexedObject
       Object.send(:remove_const, :IndexedObject)
       load File.expand_path('../../basic_mocks.rb', __FILE__)
       XapianDb::DocumentBlueprint.setup(:IndexedObject)
-      XapianDb::DocumentBlueprint.configured_classes.size.should == 1
+      expect(XapianDb::DocumentBlueprint.configured_classes.size).to eq(1)
     end
 
     it "raises an exception if a method with the same name has different type declarations" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attribute :date, :as => :date
       end
-      lambda { XapianDb::DocumentBlueprint.setup(:OtherIndexedObject) do |blueprint|
+      expect { XapianDb::DocumentBlueprint.setup(:OtherIndexedObject) do |blueprint|
         blueprint.attribute :date, :as => :number
-      end }.should raise_error ArgumentError
+      end }.to raise_error ArgumentError
     end
 
     it "allows blueprint definitions with symbols" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject)
-      XapianDb::DocumentBlueprint.blueprint_for('IndexedObject').should_not be_nil
+      expect(XapianDb::DocumentBlueprint.blueprint_for('IndexedObject')).not_to be_nil
     end
 
     it "allows blueprint definitions with strings" do
       XapianDb::DocumentBlueprint.setup('IndexedObject')
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).should_not be_nil
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)).not_to be_nil
     end
 
     it "lazy-loads blueprint classes" do
-      lambda do
+      expect do
         XapianDb::DocumentBlueprint.setup(:NotYetLoadedClass)
         class NotYetLoadedClass; end
-      end.should_not raise_error
-      XapianDb::DocumentBlueprint.blueprint_for(:NotYetLoadedClass).should_not be_nil
+      end.not_to raise_error
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:NotYetLoadedClass)).not_to be_nil
     end
   end
 
@@ -272,21 +272,21 @@ describe XapianDb::DocumentBlueprint do
     end
 
     it "returns the value number of an indexed method" do
-      XapianDb::DocumentBlueprint.value_number_for(:name).should == @position_offset + 1
+      expect(XapianDb::DocumentBlueprint.value_number_for(:name)).to eq(@position_offset + 1)
     end
 
     it "accepts a string as an argument" do
-      XapianDb::DocumentBlueprint.value_number_for("name").should == @position_offset + 1
+      expect(XapianDb::DocumentBlueprint.value_number_for("name")).to eq(@position_offset + 1)
     end
 
     it "raises an argument error if the method is not indexed" do
-      lambda { XapianDb::DocumentBlueprint.value_number_for(:not_indexed) }.should raise_error ArgumentError
+      expect { XapianDb::DocumentBlueprint.value_number_for(:not_indexed) }.to raise_error ArgumentError
     end
 
     it "raises an argument error if no blueprints are defined" do
       XapianDb::DocumentBlueprint.reset
       XapianDb::DocumentBlueprint.instance_variable_set(:@attributes, nil)
-      lambda { XapianDb::DocumentBlueprint.value_number_for(:not_indexed) }.should raise_error ArgumentError
+      expect { XapianDb::DocumentBlueprint.value_number_for(:not_indexed) }.to raise_error ArgumentError
     end
 
     it "handles multiple blueprints whith the same indexed method at different positions" do
@@ -295,11 +295,11 @@ describe XapianDb::DocumentBlueprint do
         blueprint.index :not_in_alphabetical_order
         blueprint.index :name
       end
-      XapianDb::DocumentBlueprint.value_number_for(:name).should == @position_offset + 1
+      expect(XapianDb::DocumentBlueprint.value_number_for(:name)).to eq(@position_offset + 1)
     end
 
     it "returns 0 for :indexed_class" do
-      XapianDb::DocumentBlueprint.value_number_for(:indexed_class).should == 0
+      expect(XapianDb::DocumentBlueprint.value_number_for(:indexed_class)).to eq(0)
     end
 
     it "calculates the value number in alphabetical order even if the attributes are not declared in alphabetical order" do
@@ -310,7 +310,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.attribute :name
         blueprint.attribute :array
       end
-      XapianDb::DocumentBlueprint.value_number_for(:array).should == @position_offset
+      expect(XapianDb::DocumentBlueprint.value_number_for(:array)).to eq(@position_offset)
     end
   end
 
@@ -319,7 +319,7 @@ describe XapianDb::DocumentBlueprint do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.adapter :generic
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._adapter.should be_equal XapianDb::Adapters::GenericAdapter
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._adapter).to be_equal XapianDb::Adapters::GenericAdapter
     end
   end
 
@@ -329,15 +329,15 @@ describe XapianDb::DocumentBlueprint do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attribute :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._adapter.should be_equal XapianDb::Adapters::GenericAdapter
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._adapter).to be_equal XapianDb::Adapters::GenericAdapter
     end
 
     it "returns the globally configured adapter if specified" do
-      XapianDb::Config.stub(:adapter).and_return(XapianDb::Adapters::ActiveRecordAdapter)
+      allow(XapianDb::Config).to receive(:adapter).and_return(XapianDb::Adapters::ActiveRecordAdapter)
       XapianDb::DocumentBlueprint.setup(:ActiveRecordObject) do |blueprint|
         blueprint.attribute :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:ActiveRecordObject)._adapter.should be_equal XapianDb::Adapters::ActiveRecordAdapter
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:ActiveRecordObject)._adapter).to be_equal XapianDb::Adapters::ActiveRecordAdapter
     end
 
     it "returns the adapter configured for this blueprint if specified" do
@@ -345,7 +345,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.adapter :datamapper
         blueprint.attribute :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:DatamapperObject)._adapter.should be_equal XapianDb::Adapters::DatamapperAdapter
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:DatamapperObject)._adapter).to be_equal XapianDb::Adapters::DatamapperAdapter
     end
   end
 
@@ -354,13 +354,13 @@ describe XapianDb::DocumentBlueprint do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.autoindex false
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).autoindex?.should be_false
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).autoindex?).to be_falsey
     end
 
     it "is true by default" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).autoindex?.should be_true
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).autoindex?).to be_truthy
     end
   end
 
@@ -373,25 +373,25 @@ describe XapianDb::DocumentBlueprint do
     end
 
     it "adds an attribute to the blueprint" do
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names.should include(:id)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names).to include(:id)
     end
 
     it "adds the attribute to the indexed methods by default" do
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).indexed_method_names.should include(:id)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).indexed_method_names).to include(:id)
     end
 
     it "does not index the attribute if the :index option ist set to false" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attribute :id, :index => false
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).indexed_method_names.should_not include(:id)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).indexed_method_names).not_to include(:id)
     end
 
     it "allows to specify a weight for the attribute" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attribute :id, :weight=> 10
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).weight.should == 10
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).weight).to eq(10)
     end
 
     it "accepts a block to specify complex attribute evaluation" do
@@ -404,21 +404,21 @@ describe XapianDb::DocumentBlueprint do
           end
         end
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names.should include(:complex)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names).to include(:complex)
     end
 
     it "allows to specify if the attribute should be prefixed" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attribute :id, :prefixed => false
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).prefixed.should be_false
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).prefixed).to be_falsey
     end
 
     it "throws an exception if the attribute name maps to a Xapian::Document method name" do
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names.should include(:id)
-      lambda{XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names).to include(:id)
+      expect{XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attribute :data
-      end}.should raise_error ArgumentError
+      end}.to raise_error ArgumentError
     end
   end
 
@@ -428,24 +428,24 @@ describe XapianDb::DocumentBlueprint do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attributes :id
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names.should include(:id)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names).to include(:id)
     end
 
     it "allows to declare multiple attributes in a single statement (but without options)" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attributes :id, :name, :first_name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names.should include(:id, :name, :first_name)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names).to include(:id, :name, :first_name)
     end
 
     it "throws an exception if the attribute name maps to a Xapian::Document method name" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attributes :id, :name, :first_name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names.should include(:id)
-      lambda{XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).attribute_names).to include(:id)
+      expect{XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attributes :data
-      end}.should raise_error ArgumentError
+      end}.to raise_error ArgumentError
     end
   end
 
@@ -458,38 +458,38 @@ describe XapianDb::DocumentBlueprint do
     end
 
     it "adds an indexed value to the blueprint" do
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).should be_a_kind_of XapianDb::DocumentBlueprint::IndexOptions
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id)).to be_a_kind_of XapianDb::DocumentBlueprint::IndexOptions
     end
 
     it "defaults the weight option to 1" do
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).weight.should == 1
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).weight).to eq(1)
     end
 
     it "accepts weight as an option" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.index :id, :weight => 10
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).weight.should == 10
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).options_for_indexed_method(:id).weight).to eq(10)
     end
 
     it "does not accept a type option" do
-      lambda { XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
+      expect { XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.index :date, :as => :date
-      end }.should raise_error ArgumentError
+      end }.to raise_error ArgumentError
     end
 
     it "allows to declare two methods (can distinguish this from a method with an options hash)" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.index :id, :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).indexed_method_names.should include(:id, :name)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).indexed_method_names).to include(:id, :name)
     end
 
     it "allows to declare multiple methods (but without options)" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.index :id, :name, :first_name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).indexed_method_names.should include(:id, :name, :first_name)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).indexed_method_names).to include(:id, :name, :first_name)
     end
   end
 
@@ -502,7 +502,7 @@ describe XapianDb::DocumentBlueprint do
           active == false
         }
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).instance_variable_get(:@ignore_expression).should be_a_kind_of Proc
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).instance_variable_get(:@ignore_expression)).to be_a_kind_of Proc
     end
   end
 
@@ -514,7 +514,7 @@ describe XapianDb::DocumentBlueprint do
       end
       blueprint = XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
       obj = IndexedObject.new 1
-      blueprint.should_index?(obj).should be_true
+      expect(blueprint.should_index?(obj)).to be_truthy
     end
 
     it "should return false if the ignore expression evaluates to true" do
@@ -524,7 +524,7 @@ describe XapianDb::DocumentBlueprint do
       end
       blueprint = XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
       obj = IndexedObject.new 1
-      blueprint.should_index?(obj).should be_false
+      expect(blueprint.should_index?(obj)).to be_falsey
     end
 
     it "should return true if the ignore expression evaluates to false" do
@@ -534,7 +534,7 @@ describe XapianDb::DocumentBlueprint do
       end
       blueprint = XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
       obj = IndexedObject.new 1
-      blueprint.should_index?(obj).should be_true
+      expect(blueprint.should_index?(obj)).to be_truthy
     end
   end
 
@@ -545,7 +545,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.attribute :array
         blueprint.base_query ActiveRecordObject.includes(:children)
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).lazy_base_query.should be
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).lazy_base_query).to be
     end
 
     it "converts an explicit base query expression to a proc" do
@@ -553,7 +553,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.attribute :array
         blueprint.base_query ActiveRecordObject.includes(:children)
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).lazy_base_query.should be_a Proc
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).lazy_base_query).to be_a Proc
     end
 
     it "accepts a base query expression inside a block" do
@@ -561,7 +561,7 @@ describe XapianDb::DocumentBlueprint do
         blueprint.attribute :array
         blueprint.base_query { ActiveRecordObject.includes(:children) }
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).lazy_base_query.should be_a Proc
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject).lazy_base_query).to be_a Proc
     end
   end
 
@@ -570,14 +570,14 @@ describe XapianDb::DocumentBlueprint do
     it "defaults to id if not specified" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._natural_sort_order.should == :id
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._natural_sort_order).to eq(:id)
     end
 
     it "accepts a method symbol" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.natural_sort_order :name
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._natural_sort_order.should == :name
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._natural_sort_order).to eq(:name)
     end
 
     it "accepts a block" do
@@ -586,15 +586,15 @@ describe XapianDb::DocumentBlueprint do
           @id
         end
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._natural_sort_order.should be_a Proc
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)._natural_sort_order).to be_a Proc
     end
 
     it "raises an ArgumentError, if a method name AND a block are given" do
-      lambda { XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
+      expect { XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.natural_sort_order :name do
           @id
         end
-      end }.should raise_error ArgumentError
+      end }.to raise_error ArgumentError
     end
   end
 
@@ -611,7 +611,7 @@ describe XapianDb::DocumentBlueprint do
         end
       end
 
-      expect(blueprint.dependencies).to have(1).item
+      expect(blueprint.dependencies.size).to eq(1)
       dependency = blueprint.dependencies.first
       expect(dependency.dependent_on).to eq 'OtherIndexedObject'
       expect(dependency.trigger_attributes).to eq ['name']
@@ -642,31 +642,31 @@ describe XapianDb::DocumentBlueprint do
     end
 
     it "builds an accessor module for the blueprint" do
-      @blueprint.accessors_module.should be_a_kind_of Module
+      expect(@blueprint.accessors_module).to be_a_kind_of Module
     end
 
     it "adds accessor methods for each configured field" do
-      @blueprint.accessors_module.instance_methods.should include(:id, :name, :date_of_birth)
+      expect(@blueprint.accessors_module.instance_methods).to include(:id, :name, :date_of_birth)
     end
 
     it "adds accessor methods that can handle nil" do
-      @doc.empty_field.should == ""
+      expect(@doc.empty_field).to eq("")
     end
 
     it "adds an accessor method for the class of the indexed object" do
-      @doc.indexed_class.should == "IndexedObject"
+      expect(@doc.indexed_class).to eq("IndexedObject")
     end
 
     it "adds accessor methods that deserialize values to native objects" do
-      @doc.date_of_birth.should == Date.new(2011, 1, 1)
+      expect(@doc.date_of_birth).to eq(Date.new(2011, 1, 1))
     end
 
     it "adds a method to access the document attributes as a hash" do
-      @doc.attributes.should == { "array"         => [1, "two", "2011-01-01"],
+      expect(@doc.attributes).to eq({ "array"         => [1, "two", "2011-01-01"],
                                   "date_of_birth" => Date.new(2011, 1, 1),
                                   "empty_field"   => "",
                                   "id"            => 1,
-                                  "name"          => "Kogler" }
+                                  "name"          => "Kogler" })
     end
   end
 
@@ -682,15 +682,15 @@ describe XapianDb::DocumentBlueprint do
     end
 
     it "should return a hash table" do
-      blueprint.type_map.should be_a Hash
+      expect(blueprint.type_map).to be_a Hash
     end
 
     it "contains the type of an indexed method if a type is defined" do
-      blueprint.type_map[:date].should == :date
+      expect(blueprint.type_map[:date]).to eq(:date)
     end
 
     it "contains :string for an indexed method if no type is defined" do
-      blueprint.type_map[:untyped].should == :string
+      expect(blueprint.type_map[:untyped]).to eq(:string)
     end
   end
 end

--- a/spec/xapian_db/index_writers/beanstalk_worker_spec.rb
+++ b/spec/xapian_db/index_writers/beanstalk_worker_spec.rb
@@ -21,18 +21,18 @@ describe XapianDb::IndexWriters::BeanstalkWorker do
     it "adds an object to the index" do
       @obj.save
       XapianDb.database.delete_docs_of_class @obj.class
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       XapianDb::IndexWriters::BeanstalkWorker.new.index_task :class => @obj.class.name, :id => @obj.id
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
   end
 
   describe ".delete_doc_task(options)" do
     it "removes an object from the index" do
       @obj.save
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
       XapianDb::IndexWriters::BeanstalkWorker.new.delete_doc_task :xapian_id => @obj.xapian_id
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
     end
   end
 
@@ -41,9 +41,9 @@ describe XapianDb::IndexWriters::BeanstalkWorker do
     it "adds all instances of a class to the index" do
       @obj.save
       XapianDb.database.delete_docs_of_class @obj.class
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       XapianDb::IndexWriters::BeanstalkWorker.new.reindex_class_task :class => @obj.class.name
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
   end

--- a/spec/xapian_db/index_writers/beanstalk_writer_spec.rb
+++ b/spec/xapian_db/index_writers/beanstalk_writer_spec.rb
@@ -13,27 +13,27 @@ describe XapianDb::IndexWriters::BeanstalkWriter do
   let (:object) { ActiveRecordObject.new 1, "Gernot" }
 
   before :each do
-    described_class.stub(:beanstalk).and_return(BeanstalkDummy.new)
+    allow(described_class).to receive(:beanstalk).and_return(BeanstalkDummy.new)
   end
 
   describe ".index(obj, commit=true, changed_attrs: [])" do
     it "puts the index task on the beanstalk queue" do
       changed_attrs = ['name']
-      described_class.beanstalk.should_receive(:put).with({task: "index_task", class: object.class.name, id: object.id, changed_attrs: changed_attrs }.to_json)
+      expect(described_class.beanstalk).to receive(:put).with({task: "index_task", class: object.class.name, id: object.id, changed_attrs: changed_attrs }.to_json)
       XapianDb::IndexWriters::BeanstalkWriter.index object, true, changed_attrs: changed_attrs
     end
   end
 
   describe ".delete_doc_with(xapian_id)" do
     it "puts the delete task on the beanstalk queue" do
-      described_class.beanstalk.should_receive(:put).with({ :task => "delete_doc_task", :xapian_id => object.xapian_id }.to_json)
+      expect(described_class.beanstalk).to receive(:put).with({ :task => "delete_doc_task", :xapian_id => object.xapian_id }.to_json)
       XapianDb::IndexWriters::BeanstalkWriter.delete_doc_with object.xapian_id
     end
   end
 
   describe ".reindex(klass)" do
     it "puts the reindex task on the resque queue" do
-      described_class.beanstalk.should_receive(:put).with({ :task => "reindex_class_task", :class => object.class.name }.to_json)
+      expect(described_class.beanstalk).to receive(:put).with({ :task => "reindex_class_task", :class => object.class.name }.to_json)
       XapianDb::IndexWriters::BeanstalkWriter.reindex_class ActiveRecordObject
     end
   end

--- a/spec/xapian_db/index_writers/direct_writer_spec.rb
+++ b/spec/xapian_db/index_writers/direct_writer_spec.rb
@@ -15,24 +15,24 @@ describe XapianDb::IndexWriters::DirectWriter do
       blueprint.attribute :text
     end
     @obj = IndexedObject.new(1)
-    @obj.stub!(:text).and_return("Some text")
+    allow(@obj).to receive(:text).and_return("Some text")
   end
 
   describe ".index(obj)" do
     it "adds an object to the index" do
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       XapianDb::IndexWriters::DirectWriter.index @obj
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
   end
 
   describe ".delete_doc_with(xapian_id)" do
     it "removes a document from the index" do
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       XapianDb::IndexWriters::DirectWriter.index @obj
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
       XapianDb::IndexWriters::DirectWriter.delete_doc_with @obj.xapian_id
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
     end
   end
 
@@ -54,7 +54,7 @@ describe XapianDb::IndexWriters::DirectWriter do
 
     it "adds all instances of a class to the index" do
       XapianDb::IndexWriters::DirectWriter.reindex_class DatamapperObject
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
     it "accepts a verbose option" do
@@ -64,12 +64,12 @@ describe XapianDb::IndexWriters::DirectWriter do
       rescue
       end
       XapianDb::IndexWriters::DirectWriter.reindex_class DatamapperObject, :verbose => true
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
     it "adds all instances of a class to the index" do
       XapianDb::IndexWriters::DirectWriter.reindex_class DatamapperObject
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
     it "uses the blueprint base query if specified" do
@@ -78,7 +78,7 @@ describe XapianDb::IndexWriters::DirectWriter do
         blueprint.attribute :name
         blueprint.base_query { DatamapperObject }
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:DatamapperObject).lazy_base_query.should_receive(:call).and_return DatamapperObject
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:DatamapperObject).lazy_base_query).to receive(:call).and_return DatamapperObject
       XapianDb::IndexWriters::DirectWriter.reindex_class DatamapperObject
     end
   end

--- a/spec/xapian_db/index_writers/no_op_writer_spec.rb
+++ b/spec/xapian_db/index_writers/no_op_writer_spec.rb
@@ -18,7 +18,7 @@ describe XapianDb::IndexWriters::NoOpWriter do
 
   let(:object) {
     obj = IndexedObject.new(1)
-    obj.stub!(:text).and_return("Some text")
+    allow(obj).to receive(:text).and_return("Some text")
     obj
   }
   let(:writer) { XapianDb::IndexWriters::NoOpWriter }
@@ -26,7 +26,7 @@ describe XapianDb::IndexWriters::NoOpWriter do
   describe "#index(obj)" do
     it "does nothing" do
       writer.index object
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
     end
   end
 
@@ -38,14 +38,14 @@ describe XapianDb::IndexWriters::NoOpWriter do
 
     it "does nothing" do
       writer.delete_doc_with object.xapian_id
-      XapianDb.database.size.should == 1 # the object indexed in the before block
+      expect(XapianDb.database.size).to eq(1) # the object indexed in the before block
     end
   end
 
   describe "#reindex(klass)" do
 
     it "should raise a 'not supported' exception" do
-      lambda { writer.reindex_class IndexedObject }.should raise_error "rebuild_xapian_index is not supported inside a block with auto indexing disabled"
+      expect { writer.reindex_class IndexedObject }.to raise_error "rebuild_xapian_index is not supported inside a block with auto indexing disabled"
     end
 
   end

--- a/spec/xapian_db/index_writers/resque_worker_spec.rb
+++ b/spec/xapian_db/index_writers/resque_worker_spec.rb
@@ -19,8 +19,8 @@ describe XapianDb::IndexWriters::ResqueWorker do
 
   describe ".queue" do
     it "returns the queue name specified in the config" do
-      XapianDb::Config.stub(:resque_queue) { 'my_queue' }
-      subject.queue.should == 'my_queue'
+      allow(XapianDb::Config).to receive(:resque_queue) { 'my_queue' }
+      expect(subject.queue).to eq('my_queue')
     end
   end
 
@@ -28,18 +28,18 @@ describe XapianDb::IndexWriters::ResqueWorker do
     it "adds an object to the index" do
       obj.save
       XapianDb.database.delete_docs_of_class obj.class
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       subject.perform 'index', 'class' => obj.class.name, 'id' => obj.id
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
   end
 
   describe ".delete_doc" do
     it "removes an object from the index" do
       obj.save
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
       subject.perform 'delete_doc', 'xapian_id' => obj.xapian_id
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
     end
   end
 
@@ -47,9 +47,9 @@ describe XapianDb::IndexWriters::ResqueWorker do
     it "adds all instances of a class to the index" do
       obj.save
       XapianDb.database.delete_docs_of_class obj.class
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       subject.perform 'reindex_class', 'class' => obj.class.name
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
   end
 

--- a/spec/xapian_db/index_writers/resque_writer_spec.rb
+++ b/spec/xapian_db/index_writers/resque_writer_spec.rb
@@ -15,7 +15,7 @@ describe XapianDb::IndexWriters::ResqueWriter do
   end
 
   before :each do
-    described_class.stub(:worker_class) { DummyWorker }
+    allow(described_class).to receive(:worker_class) { DummyWorker }
   end
 
   describe ".index" do
@@ -23,21 +23,21 @@ describe XapianDb::IndexWriters::ResqueWriter do
 
     it "puts the index task on the resque queue" do
       changed_attrs = ['name']
-      Resque.should_receive(:enqueue).with(DummyWorker, :index, class: 'TestIndexClass', id: 28, changed_attrs: changed_attrs )
+      expect(Resque).to receive(:enqueue).with(DummyWorker, :index, class: 'TestIndexClass', id: 28, changed_attrs: changed_attrs )
       described_class.index object, true, changed_attrs: changed_attrs
     end
   end
 
   describe ".delete_doc_with" do
     it "puts the delete task on the resque queue" do
-      Resque.should_receive(:enqueue).with(DummyWorker, :delete_doc, :xapian_id => 91)
+      expect(Resque).to receive(:enqueue).with(DummyWorker, :delete_doc, :xapian_id => 91)
       described_class.delete_doc_with 91
     end
   end
 
   describe ".reindex_class" do
     it "puts the reindex task on the resque queue" do
-      Resque.should_receive(:enqueue).with(DummyWorker, :reindex_class, :class => 'TestIndexClass')
+      expect(Resque).to receive(:enqueue).with(DummyWorker, :reindex_class, :class => 'TestIndexClass')
       described_class.reindex_class TestIndexClass
     end
   end

--- a/spec/xapian_db/index_writers/sidekiq_worker_spec.rb
+++ b/spec/xapian_db/index_writers/sidekiq_worker_spec.rb
@@ -19,8 +19,8 @@ describe XapianDb::IndexWriters::SidekiqWorker do
 
   describe ".queue" do
     it "returns the queue name specified in the config" do
-      XapianDb::Config.stub(:sidekiq_queue) { 'my_queue' }
-      subject.queue.should == 'my_queue'
+      allow(XapianDb::Config).to receive(:sidekiq_queue) { 'my_queue' }
+      expect(subject.queue).to eq('my_queue')
     end
   end
 
@@ -28,18 +28,18 @@ describe XapianDb::IndexWriters::SidekiqWorker do
     it "adds an object to the index" do
       obj.save
       XapianDb.database.delete_docs_of_class obj.class
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       subject.perform 'index', 'class' => obj.class.name, 'id' => obj.id
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
   end
 
   describe ".delete_doc" do
     it "removes an object from the index" do
       obj.save
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
       subject.perform 'delete_doc', 'xapian_id' => obj.xapian_id
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
     end
   end
 
@@ -47,9 +47,9 @@ describe XapianDb::IndexWriters::SidekiqWorker do
     it "adds all instances of a class to the index" do
       obj.save
       XapianDb.database.delete_docs_of_class obj.class
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
       subject.perform 'reindex_class', 'class' => obj.class.name
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
   end
 

--- a/spec/xapian_db/index_writers/sidekiq_writer_spec.rb
+++ b/spec/xapian_db/index_writers/sidekiq_writer_spec.rb
@@ -15,7 +15,7 @@ describe XapianDb::IndexWriters::SidekiqWriter do
   end
 
   before :each do
-    described_class.stub(:worker_class) { DummyWorker }
+    allow(described_class).to receive(:worker_class) { DummyWorker }
   end
 
   describe ".index" do
@@ -23,21 +23,21 @@ describe XapianDb::IndexWriters::SidekiqWriter do
 
     it "puts the index task on the sidekiq queue" do
       changed_attrs = ['name']
-      Sidekiq::Client.should_receive(:enqueue).with(DummyWorker, :index, class: 'TestIndexClass', id: 28, changed_attrs: changed_attrs)
+      expect(Sidekiq::Client).to receive(:enqueue).with(DummyWorker, :index, class: 'TestIndexClass', id: 28, changed_attrs: changed_attrs)
       described_class.index object, true, changed_attrs: changed_attrs
     end
   end
 
   describe ".delete_doc_with" do
     it "puts the delete task on the sidekiq queue" do
-      Sidekiq::Client.should_receive(:enqueue).with(DummyWorker, :delete_doc, :xapian_id => 91)
+      expect(Sidekiq::Client).to receive(:enqueue).with(DummyWorker, :delete_doc, :xapian_id => 91)
       described_class.delete_doc_with 91
     end
   end
 
   describe ".reindex_class" do
     it "puts the reindex task on the sidekiq queue" do
-      Sidekiq::Client.should_receive(:enqueue).with(DummyWorker, :reindex_class, :class => 'TestIndexClass')
+      expect(Sidekiq::Client).to receive(:enqueue).with(DummyWorker, :reindex_class, :class => 'TestIndexClass')
       described_class.reindex_class TestIndexClass
     end
   end

--- a/spec/xapian_db/index_writers/transactional_writer_spec.rb
+++ b/spec/xapian_db/index_writers/transactional_writer_spec.rb
@@ -18,7 +18,7 @@ describe XapianDb::IndexWriters::TransactionalWriter do
 
   let(:object) {
     obj = IndexedObject.new(1)
-    obj.stub!(:text).and_return("Some text")
+    allow(obj).to receive(:text).and_return("Some text")
     obj
   }
   let(:writer) { XapianDb::IndexWriters::TransactionalWriter.new }
@@ -26,7 +26,7 @@ describe XapianDb::IndexWriters::TransactionalWriter do
   describe "#index(obj)" do
     it "registers an index request for an object" do
       writer.index object
-      writer.index_requests.size.should == 1
+      expect(writer.index_requests.size).to eq(1)
     end
   end
 
@@ -34,14 +34,14 @@ describe XapianDb::IndexWriters::TransactionalWriter do
 
     it "registers an index request for an object" do
       writer.delete_doc_with object.xapian_id
-      writer.delete_requests.size.should == 1
+      expect(writer.delete_requests.size).to eq(1)
     end
   end
 
   describe "#reindex(klass)" do
 
     it "should raise a 'not supported' exception" do
-      lambda { writer.reindex_class IndexedObject }.should raise_error "rebuild_xapian_index is not supported in transactions"
+      expect { writer.reindex_class IndexedObject }.to raise_error "rebuild_xapian_index is not supported in transactions"
     end
 
   end
@@ -50,18 +50,18 @@ describe XapianDb::IndexWriters::TransactionalWriter do
 
     it "commits the index requests to the database", :working => true do
       writer.index object
-      XapianDb.database.size.should == 0 # not commited yet
+      expect(XapianDb.database.size).to eq(0) # not commited yet
       writer.commit_using XapianDb::IndexWriters::DirectWriter
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
     end
 
     it "commits the delete requests to the database" do
       XapianDb::IndexWriters::DirectWriter.index object
-      XapianDb.database.size.should == 1
+      expect(XapianDb.database.size).to eq(1)
       writer.delete_doc_with object.xapian_id
-      XapianDb.database.size.should == 1 # not commited yet
+      expect(XapianDb.database.size).to eq(1) # not commited yet
       writer.commit_using XapianDb::IndexWriters::DirectWriter
-      XapianDb.database.size.should == 0
+      expect(XapianDb.database.size).to eq(0)
     end
 
   end

--- a/spec/xapian_db/indexer_spec.rb
+++ b/spec/xapian_db/indexer_spec.rb
@@ -135,6 +135,23 @@ describe XapianDb::Indexer do
       expect(doc.values[1].value).to eq("fixed")
     end
 
+    it "calls the indexer preprocess callback" do
+      class Klass
+        def self.normalize_global(text); "text"; end
+      end
+      XapianDb::Config.setup do |config|
+        config.indexer_preprocess_callback Klass.method(:normalize_global)
+      end
+
+      @indexer = XapianDb::Indexer.new(@db, @blueprint)
+      doc = @indexer.build_document_for(@obj)
+
+      expect(doc.terms.map(&:term)).to include "text"
+
+      XapianDb::Config.setup do |config|
+        config.indexer_preprocess_callback nil
+      end
+    end
   end
 
   it "can handle attribute objects that return nil on to_s" do

--- a/spec/xapian_db/model_extenders/active_record_spec.rb
+++ b/spec/xapian_db/model_extenders/active_record_spec.rb
@@ -11,7 +11,7 @@ describe XapianDb::ModelExtenders::ActiveRecord do
   describe ".inherited(klass)" do
 
     it "checks if a blueprint for the klass is specified" do
-      XapianDb::DocumentBlueprint.should_receive(:configured?).with(ActiveRecordObject.name)
+      expect(XapianDb::DocumentBlueprint).to receive(:configured?).with(ActiveRecordObject.name)
       subject.inherited(ActiveRecordObject)
     end
 
@@ -19,7 +19,7 @@ describe XapianDb::ModelExtenders::ActiveRecord do
       XapianDb::DocumentBlueprint.setup(:ActiveRecordObject) do |blueprint|
         blueprint.attribute :array
       end
-      XapianDb::DocumentBlueprint.blueprint_for(:ActiveRecordObject)._adapter.should_receive(:add_class_helper_methods_to).with(ActiveRecordObject)
+      expect(XapianDb::DocumentBlueprint.blueprint_for(:ActiveRecordObject)._adapter).to receive(:add_class_helper_methods_to).with(ActiveRecordObject)
       subject.inherited(ActiveRecordObject)
     end
 

--- a/spec/xapian_db/query_parser_spec.rb
+++ b/spec/xapian_db/query_parser_spec.rb
@@ -11,19 +11,19 @@ describe XapianDb::QueryParser do
   describe ".parse" do
 
     it "returns nil if the search expression is nil" do
-      XapianDb::QueryParser.new(@db).parse(nil).should_not be
+      expect(XapianDb::QueryParser.new(@db).parse(nil)).not_to be
     end
 
     it "returns nil if the search expression is an empty string" do
-      XapianDb::QueryParser.new(@db).parse(" ").should_not be
+      expect(XapianDb::QueryParser.new(@db).parse(" ")).not_to be
     end
 
     it "returns a Xapian::Query object" do
-      XapianDb::QueryParser.new(@db).parse("foo").should be_a_kind_of(Xapian::Query)
+      expect(XapianDb::QueryParser.new(@db).parse("foo")).to be_a_kind_of(Xapian::Query)
     end
 
     it "responds to spelling_suggestion" do
-      XapianDb::QueryParser.new(@db).should respond_to(:spelling_suggestion)
+      expect(XapianDb::QueryParser.new(@db)).to respond_to(:spelling_suggestion)
     end
 
   end

--- a/spec/xapian_db/repositories/stemmer_spec.rb
+++ b/spec/xapian_db/repositories/stemmer_spec.rb
@@ -6,24 +6,24 @@ describe XapianDb::Repositories::Stemmer do
 
   describe ".stemmer_for(iso_cd)" do
     it "returns nil for iso code nil" do
-      XapianDb::Repositories::Stemmer.stemmer_for(nil).should_not be
+      expect(XapianDb::Repositories::Stemmer.stemmer_for(nil)).not_to be
     end
 
     it "returns a Xapian::Stem object for a supported language iso code" do
-      XapianDb::Repositories::Stemmer.stemmer_for(:de).should be_a_kind_of Xapian::Stem
+      expect(XapianDb::Repositories::Stemmer.stemmer_for(:de)).to be_a_kind_of Xapian::Stem
     end
 
     it "caches already used stemmers" do
       stemmer = XapianDb::Repositories::Stemmer.stemmer_for(:de)
-      XapianDb::Repositories::Stemmer.stemmer_for(:de).should be_equal stemmer
+      expect(XapianDb::Repositories::Stemmer.stemmer_for(:de)).to be_equal stemmer
     end
 
     it "accepts :none for a stemmer without a language" do
-      XapianDb::Repositories::Stemmer.stemmer_for(:none).should be_a_kind_of Xapian::Stem
+      expect(XapianDb::Repositories::Stemmer.stemmer_for(:none)).to be_a_kind_of Xapian::Stem
     end
 
     it "raises an argument error if the language is not supported" do
-      lambda {XapianDb::Repositories::Stemmer.stemmer_for(:not_supported)}.should raise_error ArgumentError
+      expect {XapianDb::Repositories::Stemmer.stemmer_for(:not_supported)}.to raise_error ArgumentError
     end
 
   end

--- a/spec/xapian_db/repositories/stopper_spec.rb
+++ b/spec/xapian_db/repositories/stopper_spec.rb
@@ -6,25 +6,25 @@ describe XapianDb::Repositories::Stopper do
 
   describe ".stopper_for(iso_cd)" do
     it "returns nil for iso code nil" do
-      XapianDb::Repositories::Stopper.stopper_for(nil).should_not be
+      expect(XapianDb::Repositories::Stopper.stopper_for(nil)).not_to be
     end
 
     it "returns a Xapian::SimpleStopper object for a supported language iso code" do
-      XapianDb::Repositories::Stopper.stopper_for(:de).should be_a_kind_of Xapian::SimpleStopper
+      expect(XapianDb::Repositories::Stopper.stopper_for(:de)).to be_a_kind_of Xapian::SimpleStopper
     end
 
     it "caches already used stoppers" do
       stopper = XapianDb::Repositories::Stopper.stopper_for(:de)
-      XapianDb::Repositories::Stopper.stopper_for(:de).should be_equal stopper
+      expect(XapianDb::Repositories::Stopper.stopper_for(:de)).to be_equal stopper
     end
 
     it "creates a stopper thata contains the stop words for its language" do
       stopper = XapianDb::Repositories::Stopper.stopper_for(:de)
-      stopper.call("und").should be_true
+      expect(stopper.call("und")).to be_truthy
     end
 
     it "returns nil if there is no stop words file for the language" do
-      XapianDb::Repositories::Stopper.stopper_for(:nb).should_not be
+      expect(XapianDb::Repositories::Stopper.stopper_for(:nb)).not_to be
     end
 
   end

--- a/spec/xapian_db/resultset_spec.rb
+++ b/spec/xapian_db/resultset_spec.rb
@@ -14,131 +14,131 @@ describe XapianDb::Resultset do
     @name = "Gernot"
 
     # Mock a Xapian search result (Xapian::Enquire)
-    @enquiry = mock(Xapian::Enquire)
-    @mset    = mock(Xapian::MSet)
+    @enquiry = double(Xapian::Enquire)
+    @mset    = double(Xapian::MSet)
 
     # Create 3 matches and docs to play with
     @matches = []
     3.times do |i|
-      match   = mock(Xapian::Match)
+      match   = double(Xapian::Match)
       doc     = Xapian::Document.new
       doc.add_value(0, IndexedObject.name)
       doc.add_value(XapianDb::DocumentBlueprint.value_number_for(:name), "#{@name}#{i}")
-      match.stub!(:document).and_return(doc)
-      match.stub!(:percent).and_return(90)
+      allow(match).to receive(:document).and_return(doc)
+      allow(match).to receive(:percent).and_return(90)
       @matches << match
     end
-    @mset.stub!(:matches_estimated).and_return(@matches.size)
-    @mset.stub!(:matches).and_return(@matches)
-    @enquiry.stub!(:mset).and_return(@mset)
+    allow(@mset).to receive(:matches_estimated).and_return(@matches.size)
+    allow(@mset).to receive(:matches).and_return(@matches)
+    allow(@enquiry).to receive(:mset).and_return(@mset)
 
   end
 
   it "behaves like an array" do
     resultset = XapianDb::Resultset.new(nil, {})
     %w(size [] each).each do |method|
-      resultset.should respond_to(method)
+      expect(resultset).to respond_to(method)
     end
   end
 
   it "is compatible with kaminari pagination" do
     resultset = XapianDb::Resultset.new(nil, {})
     %w(total_count num_pages limit_value current_page).each do |method|
-      resultset.should respond_to(method)
+      expect(resultset).to respond_to(method)
     end
   end
 
   it "is compatible with will_paginate pagination" do
     resultset = XapianDb::Resultset.new(nil, {})
-    resultset.should respond_to(:total_entries)
+    expect(resultset).to respond_to(:total_entries)
   end
 
   describe ".initialize(enquiry, options)" do
 
     it "creates a valid, empty result set if we pass nil for the enquiry" do
       resultset = XapianDb::Resultset.new(nil, {})
-      resultset.hits.should          == 0
-      resultset.size.should          == 0
-      resultset.current_page.should  == 0
-      resultset.total_pages.should   == 0
-      resultset.limit_value.should   == 0
+      expect(resultset.hits).to          eq(0)
+      expect(resultset.size).to          eq(0)
+      expect(resultset.current_page).to  eq(0)
+      expect(resultset.total_pages).to   eq(0)
+      expect(resultset.limit_value).to   eq(0)
     end
 
     it "raises an exception if an unsupported option is passed" do
-      lambda{XapianDb::Resultset.new(@enquiry, :unsupported => "?")}.should raise_error
+      expect{XapianDb::Resultset.new(@enquiry, :unsupported => "?")}.to raise_error
     end
 
     it "accepts a limit option (as a string or an integer)" do
-      @mset.stub!(:matches).and_return(@matches[0..1])
+      allow(@mset).to receive(:matches).and_return(@matches[0..1])
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :limit => "2")
-      resultset.hits.should          == 3
-      resultset.size.should          == 2
-      resultset.current_page.should  == 1
-      resultset.total_pages.should   == 2
-      resultset.total_count.should   == @matches.size
-      resultset.total_entries.should == @matches.size
+      expect(resultset.hits).to          eq(3)
+      expect(resultset.size).to          eq(2)
+      expect(resultset.current_page).to  eq(1)
+      expect(resultset.total_pages).to   eq(2)
+      expect(resultset.total_count).to   eq(@matches.size)
+      expect(resultset.total_entries).to eq(@matches.size)
     end
 
     it "accepts a per_page option (as a string or an integer)" do
-      @mset.stub!(:matches).and_return(@matches[0..1])
+      allow(@mset).to receive(:matches).and_return(@matches[0..1])
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => "2")
 
-      resultset.hits.should         == 3
-      resultset.size.should         == 2
-      resultset.current_page.should == 1
-      resultset.total_pages.should  == 2
+      expect(resultset.hits).to         eq(3)
+      expect(resultset.size).to         eq(2)
+      expect(resultset.current_page).to eq(1)
+      expect(resultset.total_pages).to  eq(2)
     end
 
     it "accepts a page number (as a string or an integer)" do
-      @mset.stub!(:matches).and_return(@matches[2..2])
+      allow(@mset).to receive(:matches).and_return(@matches[2..2])
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => "2", :page => "2")
 
-      resultset.hits.should         == 3
-      resultset.size.should         == 1
-      resultset.current_page.should == 2
-      resultset.total_pages.should  == 2
+      expect(resultset.hits).to         eq(3)
+      expect(resultset.size).to         eq(1)
+      expect(resultset.current_page).to eq(2)
+      expect(resultset.total_pages).to  eq(2)
     end
 
     it "accepts nil as a page number" do
-      @mset.stub!(:matches).and_return(@matches[0..1])
+      allow(@mset).to receive(:matches).and_return(@matches[0..1])
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => nil)
 
-      resultset.hits.should         == 3
-      resultset.size.should         == 2
-      resultset.current_page.should == 1
-      resultset.total_pages.should  == 2
+      expect(resultset.hits).to         eq(3)
+      expect(resultset.size).to         eq(2)
+      expect(resultset.current_page).to eq(1)
+      expect(resultset.total_pages).to  eq(2)
     end
 
     it "raises an exception if page is requested that does not exist" do
-      lambda{XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 3)}.should raise_error
+      expect{XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 3)}.to raise_error
     end
 
     it "should populate itself with found xapian documents" do
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 2)
-      resultset.first.should be_a_kind_of(Xapian::Document)
+      expect(resultset.first).to be_a_kind_of(Xapian::Document)
     end
 
     it "should decorate the Xapian documents with attribute accessors" do
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 2)
       doc = resultset.first
-      doc.respond_to?(:name).should be_true
-      doc.name.should == "#{@name}0"
+      expect(doc.respond_to?(:name)).to be_truthy
+      expect(doc.name).to eq("#{@name}0")
     end
 
     it "should add the score of a match to the document" do
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 2)
       doc = resultset.first
-      doc.score.should == 90
+      expect(doc.score).to eq(90)
     end
 
     it "can handle a page option as a string" do
-      @mset.stub!(:matches).and_return(@matches[2..2])
+      allow(@mset).to receive(:matches).and_return(@matches[2..2])
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => "2")
 
-      resultset.hits.should         == 3
-      resultset.size.should         == 1
-      resultset.current_page.should == 2
-      resultset.total_pages.should  == 2
+      expect(resultset.hits).to         eq(3)
+      expect(resultset.size).to         eq(1)
+      expect(resultset.current_page).to eq(2)
+      expect(resultset.total_pages).to  eq(2)
     end
 
   end
@@ -147,12 +147,12 @@ describe XapianDb::Resultset do
 
     it "should return nil if we are at page 1" do
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 1)
-      resultset.previous_page.should_not be
+      expect(resultset.previous_page).not_to be
     end
 
     it "should return 1 if we are at page 2" do
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 2)
-      resultset.previous_page.should == 1
+      expect(resultset.previous_page).to eq(1)
     end
 
   end
@@ -161,12 +161,12 @@ describe XapianDb::Resultset do
 
     it "should return 2 if we are at page 1" do
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 1)
-      resultset.next_page.should == 2
+      expect(resultset.next_page).to eq(2)
     end
 
     it "should return nil if we are on the last page" do
       resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 2)
-      resultset.next_page.should_not be
+      expect(resultset.next_page).not_to be
     end
   end
 

--- a/spec/xapian_db/resultset_spec.rb
+++ b/spec/xapian_db/resultset_spec.rb
@@ -65,7 +65,7 @@ describe XapianDb::Resultset do
     end
 
     it "raises an exception if an unsupported option is passed" do
-      expect{XapianDb::Resultset.new(@enquiry, :unsupported => "?")}.to raise_error
+      expect{XapianDb::Resultset.new(@enquiry, :unsupported => "?")}.to raise_error 'unsupported options for resultset: {:unsupported=>"?"}'
     end
 
     it "accepts a limit option (as a string or an integer)" do
@@ -110,7 +110,7 @@ describe XapianDb::Resultset do
     end
 
     it "raises an exception if page is requested that does not exist" do
-      expect{XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 3)}.to raise_error
+      expect{XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 3)}.to raise_error "page  does not exist"
     end
 
     it "should populate itself with found xapian documents" do

--- a/spec/xapian_db/utilities_spec.rb
+++ b/spec/xapian_db/utilities_spec.rb
@@ -9,7 +9,7 @@ describe XapianDb::Utilities do
   describe ".constantize(camel_cased_word)" do
 
     it "can resolve Namespaces" do
-      constantize("Namespace::IndexedObject").should be_equal Namespace::IndexedObject
+      expect(constantize("Namespace::IndexedObject")).to be_equal Namespace::IndexedObject
     end
 
   end

--- a/spec/xapian_db_spec.rb
+++ b/spec/xapian_db_spec.rb
@@ -14,7 +14,7 @@ describe XapianDb do
       XapianDb.setup do |config|
         config.database :memory
       end
-      XapianDb.database.should be_a_kind_of XapianDb::InMemoryDatabase
+      expect(XapianDb.database).to be_a_kind_of XapianDb::InMemoryDatabase
     end
 
   end
@@ -23,16 +23,16 @@ describe XapianDb do
 
     it "should create an in memory database by default" do
       db = XapianDb.create_db
-      db.reader.should be_a_kind_of(Xapian::Database)
-      db.writer.should be_a_kind_of(Xapian::Database)
+      expect(db.reader).to be_a_kind_of(Xapian::Database)
+      expect(db.writer).to be_a_kind_of(Xapian::Database)
     end
 
     it "should create a database on disk if a path is given" do
       temp_dir = "/tmp/xapiandb"
       db = XapianDb.create_db(:path => temp_dir)
-      db.reader.should be_a_kind_of(Xapian::Database)
-      db.writer.should be_a_kind_of(Xapian::WritableDatabase)
-      File.exists?(temp_dir).should be_true
+      expect(db.reader).to be_a_kind_of(Xapian::Database)
+      expect(db.writer).to be_a_kind_of(Xapian::WritableDatabase)
+      expect(File.exists?(temp_dir)).to be_truthy
       FileUtils.rm_rf temp_dir
     end
 
@@ -42,19 +42,19 @@ describe XapianDb do
 
     it "should open an in memory database by default" do
       db = XapianDb.open_db
-      db.reader.should be_a_kind_of(Xapian::Database)
-      db.writer.should be_a_kind_of(Xapian::Database)
+      expect(db.reader).to be_a_kind_of(Xapian::Database)
+      expect(db.writer).to be_a_kind_of(Xapian::Database)
     end
 
     it "should open a database on disk if a path is given" do
       # First we create a test database
       temp_dir = "/tmp/xapiandb"
       db = XapianDb.create_db(:path => temp_dir)
-      File.exists?(temp_dir).should be_true
+      expect(File.exists?(temp_dir)).to be_truthy
 
       # Now we try to open the created database again
       db = XapianDb.open_db(:path => temp_dir)
-      db.reader.should be_a_kind_of(Xapian::Database)
+      expect(db.reader).to be_a_kind_of(Xapian::Database)
       FileUtils.rm_rf temp_dir
     end
 
@@ -69,11 +69,11 @@ describe XapianDb do
     end
 
     it "should delegate the search to the current database" do
-      XapianDb.search("Something").should be_a_kind_of(XapianDb::Resultset)
+      expect(XapianDb.search("Something")).to be_a_kind_of(XapianDb::Resultset)
     end
 
     it "accepts per_page and page options" do
-      XapianDb.search("Something", :per_page => 10, :page => 1).should be_a_kind_of(XapianDb::Resultset)
+      expect(XapianDb.search("Something", :per_page => 10, :page => 1)).to be_a_kind_of(XapianDb::Resultset)
     end
 
     describe "with an order expression" do
@@ -84,28 +84,28 @@ describe XapianDb do
         end
         indexer = XapianDb::Indexer.new XapianDb.database, XapianDb::DocumentBlueprint.blueprint_for(:IndexedObject)
         obj1 = IndexedObject.new(1)
-        obj1.stub!(:text).and_return "A text"
+        allow(obj1).to receive(:text).and_return "A text"
         XapianDb.database.store_doc indexer.build_document_for(obj1)
         obj2 = IndexedObject.new(2)
-        obj2.stub!(:text).and_return "B text"
+        allow(obj2).to receive(:text).and_return "B text"
         XapianDb.database.store_doc indexer.build_document_for(obj2)
         XapianDb.database.commit
       end
 
       it "should raise an argument error if the :order option contains an unknown attribute" do
-        lambda { XapianDb.search "text", :order => :unkown }.should raise_error ArgumentError
+        expect { XapianDb.search "text", :order => :unkown }.to raise_error ArgumentError
       end
 
       it "should accept an :order option" do
         result = XapianDb.search "text", :order => :text
-        result.first.text.should == "A text"
-        result.last.text.should == "B text"
+        expect(result.first.text).to eq("A text")
+        expect(result.last.text).to eq("B text")
       end
 
       it "should accept an :sort_decending option" do
         result = XapianDb.search "text", :order => :text, :sort_decending => true
-        result.first.text.should == "B text"
-        result.last.text.should == "A text"
+        expect(result.first.text).to eq("B text")
+        expect(result.last.text).to eq("A text")
       end
 
     end
@@ -121,7 +121,7 @@ describe XapianDb do
       XapianDb::DocumentBlueprint.setup(:IndexedObject) do |blueprint|
         blueprint.attribute :text
       end
-      XapianDb.facets(:text, "Something").should be_a_kind_of(Hash)
+      expect(XapianDb.facets(:text, "Something")).to be_a_kind_of(Hash)
     end
 
   end
@@ -147,19 +147,19 @@ describe XapianDb do
     it "updates the xapian document belonging to the object" do
       @object = ActiveRecordObject.new(1, "Kogler")
       @object.save
-      XapianDb.search("Kogler").size.should == 1
-      @object.stub!(:name).and_return "renamed"
+      expect(XapianDb.search("Kogler").size).to eq(1)
+      allow(@object).to receive(:name).and_return "renamed"
       XapianDb.reindex(@object)
-      XapianDb.search("renamed").size.should == 1
+      expect(XapianDb.search("renamed").size).to eq(1)
     end
 
     it "deletes the xapian document if the ignore_if clause evaluates to false" do
       @object = ActiveRecordObject.new(1, "Kogler")
       @object.save
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
       @object.date = Date.today + 1
       XapianDb.reindex(@object)
-      XapianDb.search("Kogler").size.should == 0
+      expect(XapianDb.search("Kogler").size).to eq(0)
     end
 
   end
@@ -176,8 +176,8 @@ describe XapianDb do
 
     it "does nothing if no blueprints are configured" do
       XapianDb::DocumentBlueprint.reset
-      lambda{XapianDb.rebuild_xapian_index}.should_not raise_error
-      XapianDb.rebuild_xapian_index.should be_false
+      expect{XapianDb.rebuild_xapian_index}.not_to raise_error
+      expect(XapianDb.rebuild_xapian_index).to be_falsey
     end
 
     it "rebuilds the index for all blueprints" do
@@ -187,16 +187,16 @@ describe XapianDb do
       @object = ActiveRecordObject.new(1, "Kogler")
       @object.save
 
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
 
       # We reopen the in memory database to destroy the index
       XapianDb.setup do |config|
         config.database :memory
       end
-      XapianDb.search("Kogler").size.should == 0
+      expect(XapianDb.search("Kogler").size).to eq(0)
 
       XapianDb.rebuild_xapian_index
-      XapianDb.search("Kogler").size.should == 1
+      expect(XapianDb.search("Kogler").size).to eq(1)
     end
 
     it "ignores blueprints that describe plain ruby classes" do
@@ -208,7 +208,7 @@ describe XapianDb do
       XapianDb.setup do |config|
         config.database :memory
       end
-      lambda {XapianDb.rebuild_xapian_index}.should_not raise_error
+      expect {XapianDb.rebuild_xapian_index}.not_to raise_error
     end
 
   end
@@ -234,24 +234,24 @@ describe XapianDb do
 
     it "should should get the objects by date" do
       result = XapianDb.search("date:#{Date.today.strftime('%Y-%m-%d')}")
-      result.size.should == 1
-      result.first.data.should == "ActiveRecordObject-2"
+      expect(result.size).to eq(1)
+      expect(result.first.data).to eq("ActiveRecordObject-2")
     end
 
     it "should find all objects with a full range" do
-      XapianDb.search("date:#{@object1.date.strftime('%Y-%m-%d')}..#{@object3.date.strftime('%Y-%m-%d')}").should have(3).items
+      expect(XapianDb.search("date:#{@object1.date.strftime('%Y-%m-%d')}..#{@object3.date.strftime('%Y-%m-%d')}").size).to eq(3)
     end
 
     it "should find selection of objects with partial range" do
-      XapianDb.search("date:#{@object2.date.strftime('%Y-%m-%d')}..#{@object3.date.strftime('%Y-%m-%d')}").should have(2).items
+      expect(XapianDb.search("date:#{@object2.date.strftime('%Y-%m-%d')}..#{@object3.date.strftime('%Y-%m-%d')}").size).to eq(2)
     end
 
     it "should find selection of objects with open ending range" do
-      XapianDb.search("date:#{@object3.date.strftime('%Y-%m-%d')}..").should have(1).item
+      expect(XapianDb.search("date:#{@object3.date.strftime('%Y-%m-%d')}..").size).to eq(1)
     end
 
     it "should find selection of objects with open beginning range" do
-      XapianDb.search("date:..#{@object2.date.strftime('%Y-%m-%d')}").should have(2).items
+      expect(XapianDb.search("date:..#{@object2.date.strftime('%Y-%m-%d')}").size).to eq(2)
     end
   end
 
@@ -276,24 +276,24 @@ describe XapianDb do
 
     it "should should get the objects by number" do
       result = XapianDb.search("age:31")
-      result.size.should == 1
-      result.first.data.should == "ActiveRecordObject-2"
+      expect(result.size).to eq(1)
+      expect(result.first.data).to eq("ActiveRecordObject-2")
     end
 
     it "should find all objects with a full range" do
-      XapianDb.search("age:30..32").should have(3).items
+      expect(XapianDb.search("age:30..32").size).to eq(3)
     end
 
     it "should find selection of objects with partial range" do
-      XapianDb.search("age:31..32").should have(2).items
+      expect(XapianDb.search("age:31..32").size).to eq(2)
     end
 
     it "should find selection of objects with open ending range" do
-      XapianDb.search("age:32..").should have(1).item
+      expect(XapianDb.search("age:32..").size).to eq(1)
     end
 
     it "should find selection of objects with open beginning range" do
-      XapianDb.search("age:..31").should have(2).items
+      expect(XapianDb.search("age:..31").size).to eq(2)
     end
   end
 
@@ -317,19 +317,19 @@ describe XapianDb do
     end
 
     it "should find all objects with a full range" do
-      XapianDb.search("name:Adam..Chris").should have(3).items
+      expect(XapianDb.search("name:Adam..Chris").size).to eq(3)
     end
 
     it "should find selection of objects with partial range" do
-      XapianDb.search("name:Bernard..Chris").should have(2).items
+      expect(XapianDb.search("name:Bernard..Chris").size).to eq(2)
     end
 
     it "should find selection of objects with open ending range" do
-      XapianDb.search("name:Chris..").should have(1).item
+      expect(XapianDb.search("name:Chris..").size).to eq(1)
     end
 
     it "should find selection of objects with open beginning range" do
-      XapianDb.search("name:..Bernard").should have(2).items
+      expect(XapianDb.search("name:..Bernard").size).to eq(2)
     end
   end
 
@@ -356,14 +356,14 @@ describe XapianDb do
         XapianDb.transaction do
           object.save
         end
-        XapianDb.database.size.should == 1
+        expect(XapianDb.database.size).to eq(1)
       end
 
       it "reraises exceptions" do
-        lambda { XapianDb.transaction do
+        expect { XapianDb.transaction do
           object.save
           raise "oops"
-        end }.should raise_error "oops"
+        end }.to raise_error "oops"
       end
 
       it "does not index the objects saved in the block if the block raises an error" do
@@ -374,14 +374,14 @@ describe XapianDb do
           end
           rescue
         end
-        XapianDb.database.size.should == 0
+        expect(XapianDb.database.size).to eq(0)
       end
 
       it "logs exceptions if used within a rails app" do
-        Rails = mock "Rails"
-        logger = mock "logger"
-        Rails.stub(:logger).and_return logger
-        logger.should_receive :error
+        Rails = double "Rails"
+        logger = double "logger"
+        allow(Rails).to receive(:logger).and_return logger
+        expect(logger).to receive :error
 
         begin
           XapianDb.transaction do
@@ -390,7 +390,7 @@ describe XapianDb do
           end
           rescue
         end
-        XapianDb.database.size.should == 0
+        expect(XapianDb.database.size).to eq(0)
       end
 
     end
@@ -400,21 +400,21 @@ describe XapianDb do
 
       describe ".index(obj)" do
         it "delegates the request to the configured writer" do
-          XapianDb::Config.writer.should_receive(:index).once
+          expect(XapianDb::Config.writer).to receive(:index).once
           XapianDb.index object
         end
       end
 
       describe ".delete_doc_with(xapian_id)" do
         it "delegates the request to the configured writer" do
-          XapianDb::Config.writer.should_receive(:delete_doc_with).once
+          expect(XapianDb::Config.writer).to receive(:delete_doc_with).once
           XapianDb.delete_doc_with object.xapian_id
         end
       end
 
       describe ".reindex_class(klass)" do
         it "delegates the request to the configured writer" do
-          XapianDb::Config.writer.should_receive(:reindex_class).once
+          expect(XapianDb::Config.writer).to receive(:reindex_class).once
           XapianDb.reindex_class object.class
         end
       end
@@ -445,14 +445,14 @@ describe XapianDb do
         XapianDb.auto_indexing_disabled do
           object.save
         end
-        XapianDb.database.size.should == 0
+        expect(XapianDb.database.size).to eq(0)
       end
 
       it "reraises exceptions" do
-        lambda { XapianDb.auto_indexing_disabled do
+        expect { XapianDb.auto_indexing_disabled do
           object.save
           raise "oops"
-        end }.should raise_error "oops"
+        end }.to raise_error "oops"
       end
 
     end

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ruby-progressbar"
   s.add_development_dependency "resque",           ">= 1.19.0"
   s.add_development_dependency "sidekiq",          ">= 2.13.0"
-  s.add_development_dependency "xapian-ruby",      "= 1.2.15.1"
+  s.add_development_dependency "xapian-ruby",      "= 1.2.21"
   s.add_development_dependency "pry-rails"
 
   s.files         = Dir.glob("lib/**/*") + Dir.glob("tasks/*") + Dir.glob("xapian_source/*") + %w(LICENSE README.rdoc CHANGELOG.md Rakefile)

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "daemons", ">= 1.0.10"
 
   s.add_development_dependency "guard"
-  s.add_development_dependency "rspec",            ">= 2.3.1"
+  s.add_development_dependency "rspec",            ">= 2.99.0"
   s.add_development_dependency "simplecov",        ">= 0.3.7"
   s.add_development_dependency "beanstalk-client", ">= 1.1.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
This pull requests
 - updates the travis.yml to run with for 2.0.0 and 2.2.x and drops 1.9.3
 - converts the spec to  use the new 3.x syntax
 - adds support for a transformer method (globally configurable or by blueprint) that allows changing the indexed terms with a Ruby method