### PR TITLE
Added offset option for Resultset

### DIFF
--- a/lib/xapian_db/resultset.rb
+++ b/lib/xapian_db/resultset.rb
@@ -45,9 +45,8 @@ module XapianDb
     #   Pass nil to get an empty result set.
     # @param [Hash] options
     # @option options [Integer] :db_size The current size (nr of docs) of the database
-    # @option options [Integer] :limit The maximum number of documents to retrieve (in total, not per request)
+    # @option options [Integer] :limit The maximum number of documents to retrieve
     # @option options [Integer] :offset The index of the first result to retrieve
-    # @option options [Integer] :count The maximum number of documents to retrieve per request (analogous to "limit" in SQL)
     # @option options [Integer] :page (1) The page number to retrieve
     # @option options [Integer] :per_page (10) How many docs per page? Ignored if a limit option is given
     # @option options [String] :spelling_suggestion (nil) The spelling corrected query (if a language is configured)
@@ -59,28 +58,27 @@ module XapianDb
       @spelling_suggestion = params.delete :spelling_suggestion
       limit                = params.delete :limit
       offset               = params.delete :offset
-      count                = params.delete :count
       page                 = params.delete :page
       per_page             = params.delete :per_page
       raise ArgumentError.new "unsupported options for resultset: #{params}" if params.size > 0
       raise ArgumentError.new "db_size option is required" unless db_size
-      raise ArgumentError.new "impossible combination of parameters" unless (page.nil? && per_page.nil?) || (offset.nil? && count.nil?)
 
-      calculated_page = offset.nil? || count.nil? ? nil : (offset.to_f / count.to_f) + 1
+      raise ArgumentError.new "impossible combination of parameters" unless per_page.nil? || limit.nil? || per_page == limit
 
-      limit    = limit.nil? ? db_size : limit.to_i
-      per_page = per_page.nil? ? (count.nil? ? limit.to_i : count.to_i) : per_page.to_i
-      page     = page.nil? ? (calculated_page.nil? ? 1 : calculated_page) : page.to_i
-      offset   = offset.nil? ? (page - 1) * per_page : offset.to_i
-      count    = count.nil? ? (offset + per_page < limit ? per_page : limit - offset) : count.to_i
+      calculated_page = offset.nil? || limit.nil? ? nil : (offset.to_f / limit.to_f) + 1
+      limit           = limit.nil? ? db_size : limit.to_i
+      per_page        = per_page.nil? ? limit.to_i : per_page.to_i
 
-      raise ArgumentError.new "page #{page} does not exist" if (page - 1) * per_page > db_size
+      raise ArgumentError.new "impossible combination of parameters" unless offset.nil? || page.nil? || ((page - 1) * per_page) == offset
 
+      page   = page.nil? ? (calculated_page.nil? ? 1 : calculated_page) : page.to_i
+      offset = offset.nil? ? (page - 1) * per_page : offset.to_i
+      count  = per_page < limit ? per_page : limit
+
+      return build_empty_resultset if (page - 1) * per_page > db_size
       result_window = enquiry.mset(offset, count)
       @hits = result_window.matches_estimated
       return build_empty_resultset if @hits == 0
-
-      raise ArgumentError.new "page #{page} does not exist within given limit" if @hits > 0 && offset >= limit
 
       self.replace result_window.matches.map{|match| decorate(match).document}
       @total_pages  = (@hits / per_page.to_f).ceil

--- a/lib/xapian_db/resultset.rb
+++ b/lib/xapian_db/resultset.rb
@@ -63,17 +63,17 @@ module XapianDb
       raise ArgumentError.new "unsupported options for resultset: #{params}" if params.size > 0
       raise ArgumentError.new "db_size option is required" unless db_size
 
-      raise ArgumentError.new "impossible combination of parameters" unless per_page.nil? || limit.nil? || per_page == limit
+      unless (page.nil? && per_page.nil?) || (limit.nil? && offset.nil?)
+        raise ArgumentError.new "Impossible combination of parameters. Either pass page and/or per_page, or limit and/or offset."
+      end
 
       calculated_page = offset.nil? || limit.nil? ? nil : (offset.to_f / limit.to_f) + 1
-      limit           = limit.nil? ? db_size : limit.to_i
-      per_page        = per_page.nil? ? limit.to_i : per_page.to_i
 
-      raise ArgumentError.new "impossible combination of parameters" unless offset.nil? || page.nil? || ((page - 1) * per_page) == offset
-
-      page   = page.nil? ? (calculated_page.nil? ? 1 : calculated_page) : page.to_i
-      offset = offset.nil? ? (page - 1) * per_page : offset.to_i
-      count  = per_page < limit ? per_page : limit
+      limit    = limit.nil? ? db_size : limit.to_i
+      per_page = per_page.nil? ? limit.to_i : per_page.to_i
+      page     = page.nil? ? (calculated_page.nil? ? 1 : calculated_page) : page.to_i
+      offset   = offset.nil? ? (page - 1) * per_page : offset.to_i
+      count    = per_page < limit ? per_page : limit
 
       return build_empty_resultset if (page - 1) * per_page > db_size
       result_window = enquiry.mset(offset, count)

--- a/spec/xapian_db/resultset_spec.rb
+++ b/spec/xapian_db/resultset_spec.rb
@@ -125,16 +125,9 @@ describe XapianDb::Resultset do
       expect(XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, :page => 3).count).to eq(0)
     end
 
-    it "raises an exception if incompatible elements of both per_page and limit are given" do
-      expect{XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, limit: 3)}.to raise_error ArgumentError, "impossible combination of parameters"
-    end
-
-    it "raises an exception if incompatible elements of both page / per_page and offset / limit are given" do
-      expect{XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, page: 2, offset: 1, limit: 2)}.to raise_error ArgumentError, "impossible combination of parameters"
-    end
-
-    it "raises no exception if compatible elements of both page / per_page and offset / limit are given" do
-      expect{XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, page: 2, offset: 2, limit: 2)}.not_to raise_error
+    it "raises an exception if elements of both page / per_page and offset / limit are given" do
+      expected_error = "Impossible combination of parameters. Either pass page and/or per_page, or limit and/or offset."
+      expect{XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, page: 2, offset: 1, limit: 2)}.to raise_error ArgumentError, expected_error
     end
 
     it "should populate itself with found xapian documents" do

--- a/spec/xapian_db/resultset_spec.rb
+++ b/spec/xapian_db/resultset_spec.rb
@@ -80,20 +80,9 @@ describe XapianDb::Resultset do
       expect(resultset.total_entries).to eq(@matches.size)
     end
 
-    it "accepts a count option (as a string or an integer)" do
-      allow(@mset).to receive(:matches).and_return(@matches[0..1])
-      resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :count => "2")
-      expect(resultset.hits).to          eq(3)
-      expect(resultset.size).to          eq(2)
-      expect(resultset.current_page).to  eq(1)
-      expect(resultset.total_pages).to   eq(2)
-      expect(resultset.total_count).to   eq(@matches.size)
-      expect(resultset.total_entries).to eq(@matches.size)
-    end
-
     it "accepts an offset option (as a string or an integer)" do
       allow(@mset).to receive(:matches).and_return(@matches[1..2])
-      resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :count => "2", offset: "1")
+      resultset = XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :limit => "2", offset: "1")
       expect(resultset.hits).to          eq(3)
       expect(resultset.size).to          eq(2)
       expect(resultset.current_page).to  eq(1.5)
@@ -132,17 +121,20 @@ describe XapianDb::Resultset do
       expect(resultset.total_pages).to  eq(2)
     end
 
-    it "raises an exception if page is requested that does not exist" do
-      expect{XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 3)}.to raise_error ArgumentError, "page 3 does not exist"
+    it "returns an empty result set if page is requested that does not exist" do
+      expect(XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, :page => 3).count).to eq(0)
     end
 
-    it "raises an exception if page is requested that does not exist within given limit" do
-      expect{XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 2, limit: 2)}.to raise_error ArgumentError, "page 2 does not exist within given limit"
+    it "raises an exception if incompatible elements of both per_page and limit are given" do
+      expect{XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, limit: 3)}.to raise_error ArgumentError, "impossible combination of parameters"
     end
 
-    it "raises an exception if elements of both page / per_page and offset / count are given" do
-      expect{XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, :page => 2, offset: 1, count: 3)}.to raise_error ArgumentError, "impossible combination of parameters"
-      expect{XapianDb::Resultset.new(@enquiry, :db_size => @matches.size, :per_page => 2, offset: 1)}.to raise_error ArgumentError, "impossible combination of parameters"
+    it "raises an exception if incompatible elements of both page / per_page and offset / limit are given" do
+      expect{XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, page: 2, offset: 1, limit: 2)}.to raise_error ArgumentError, "impossible combination of parameters"
+    end
+
+    it "raises no exception if compatible elements of both page / per_page and offset / limit are given" do
+      expect{XapianDb::Resultset.new(@enquiry, db_size: @matches.size, per_page: 2, page: 2, offset: 2, limit: 2)}.not_to raise_error
     end
 
     it "should populate itself with found xapian documents" do


### PR DESCRIPTION
We handle pagination ourselves in the project we're using Xapian in (or rather, only need limit and offset for endless scrolling and thus don't want an entire gem for this), so we needed something analogous to SQL's limit and offset.

It looks like breaking the semantics of `:limit` and making it analogous to the SQL limit is not an option, for obvious reasons. So I added a new parameter called `:count` instead, analogous to Xapian's API.

I'll gladly accept feedback.

<hr>

I added a new exception if a too high page number is requested, out of consistency considerations. The behaviour before was this:

* A too high page was requested without limit :point_right: exception from Xapian::MSet
* A too high page was requested with limit :point_right: exception from xapian_db

The new behaviour is like this:

* A too high page was requested without limit :point_right: exception from xapian_db
* A too high page was requested with limit :point_right: exception from xapian_db