### PR TITLE
XapianDb.database.delete_docs_of_class should delete docs of descendant classes, too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .rvmrc
 .bundle
 coverage/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Changes:
 
+  - The required Ruby version is now 2.0.0 since we started using keyword parameters in method definitions 
   - Ability do define and handle dependencies between blueprints (see README)
   - explicit order option for searches
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [next]
+
+Fixes:
+
+  - `XapianDb.database.delete_docs_of_class(klass)` now deletes docs of all descendants of `klass`, too (if tracked)
+
 ##1.3.6 (August 14th, 2015)
 
 Changes:

--- a/README.rdoc
+++ b/README.rdoc
@@ -34,7 +34,7 @@ I tried hard but I couldn't find such a thing so I decided to write it, based on
 
 * ruby 2.0.0 or newer
 * rails 3.0 or newer (if you want to use it with rails)
-* xapian-core and xapian-ruby binaries installed
+* xapian-core and xapian-ruby binaries 1.2.x installed
 
 == Installing xapian binaries
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -32,7 +32,7 @@ I tried hard but I couldn't find such a thing so I decided to write it, based on
 
 == Requirements
 
-* ruby 1.9.2 or newer
+* ruby 2.0.0 or newer
 * rails 3.0 or newer (if you want to use it with rails)
 * xapian-core and xapian-ruby binaries installed
 

--- a/examples/basic.rb
+++ b/examples/basic.rb
@@ -19,6 +19,9 @@ db = XapianDb.create_db
 # 2: Define a class which should get indexed; we define a class that
 # could be an ActiveRecord or Datamapper Domain class
 class Person
+  # If you are using inheritance hierarchies among indexed classes outside of ActiveRecord,
+  # using DescendantsTracker helps with rebuilding the Xapian index for a given class and all its subclasses.
+  extend DescendantsTracker
 
   attr_accessor :id, :name, :first_name, :date_of_birth
 

--- a/lib/xapian_db/database.rb
+++ b/lib/xapian_db/database.rb
@@ -35,10 +35,19 @@ module XapianDb
       true
     end
 
-    # Delete all docs of a specific class
+    # Delete all docs of a specific class.
+    #
+    # If `klass` tracks its descendants, then docs of any subclasses will be deleted, too.
+    # (ActiveRecord does this by default; the gem 'descendants_tracker' offers an alternative.)
+    #
     # @param [Class] klass A class that has a {XapianDb::DocumentBlueprint} configuration
     def delete_docs_of_class(klass)
       writer.delete_document("C#{klass}")
+      if klass.respond_to? :descendants
+        klass.descendants.each do |subclass|
+          writer.delete_document("C#{subclass}")
+        end
+      end
       true
     end
 

--- a/spec/basic_mocks.rb
+++ b/spec/basic_mocks.rb
@@ -9,7 +9,7 @@ class String
     self # not really important what we return
   end
 
-  def parameterize 
+  def parameterize
     self # not really important what we return
   end
 
@@ -22,6 +22,23 @@ class IndexedObject
   def initialize(id)
     @id = id
   end
+end
+
+class IndexedObjectSubclass < IndexedObject
+end
+
+require 'descendants_tracker'
+class IndexedObjectDT
+  extend DescendantsTracker
+
+  attr_reader :id
+
+  def initialize(id)
+    @id = id
+  end
+end
+
+class IndexedObjectTrackedSubclass < IndexedObjectDT
 end
 
 class OtherIndexedObject

--- a/spec/xapian_db/document_blueprint_spec.rb
+++ b/spec/xapian_db/document_blueprint_spec.rb
@@ -226,9 +226,12 @@ describe XapianDb::DocumentBlueprint do
     it "does replace the blueprint for a class if the class is reloaded" do
       XapianDb::DocumentBlueprint.setup(:IndexedObject)
       expect(XapianDb::DocumentBlueprint.configured_classes.size).to eq(1)
+
       # reload IndexedObject
       Object.send(:remove_const, :IndexedObject)
+      Object.send(:remove_const, :IndexedObjectSubclass)
       load File.expand_path('../../basic_mocks.rb', __FILE__)
+
       XapianDb::DocumentBlueprint.setup(:IndexedObject)
       expect(XapianDb::DocumentBlueprint.configured_classes.size).to eq(1)
     end

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ruby-progressbar"
   s.add_development_dependency "resque",           ">= 1.19.0"
   s.add_development_dependency "sidekiq",          ">= 2.13.0"
-  s.add_development_dependency "xapian-ruby",      "= 1.2.21"
+  s.add_development_dependency "xapian-ruby",      "= 1.2.22"
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "descendants_tracker"
 

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.homepage     = %q{https://github.com/garaio/xapian_db}
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Xapian-DB", "--main", "README.rdoc"]
 
-  s.required_rubygems_version = ">=1.3.6"
+  s.required_ruby_version     = ">= 2.0.0"
+  s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "daemons", ">= 1.0.10"
 

--- a/xapian_db.gemspec
+++ b/xapian_db.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sidekiq",          ">= 2.13.0"
   s.add_development_dependency "xapian-ruby",      "= 1.2.21"
   s.add_development_dependency "pry-rails"
+  s.add_development_dependency "descendants_tracker"
 
   s.files         = Dir.glob("lib/**/*") + Dir.glob("tasks/*") + Dir.glob("xapian_source/*") + %w(LICENSE README.rdoc CHANGELOG.md Rakefile)
   s.require_path  = "lib"


### PR DESCRIPTION
@gernotkogler We spoke about this.

If a descendants tracking mechanism is employed, then `XapianDb.atabase.delete_docs_of_class` now uses it to delete docs of descendant classes, too. 