### PR TITLE
Segmentation Fault fix

### DIFF
--- a/lib/xapian_db/query_parser.rb
+++ b/lib/xapian_db/query_parser.rb
@@ -35,6 +35,10 @@ module XapianDb
 
       # Add the searchable prefixes to allow searches by field
       # (like "name:Kogler")
+      processors = [] # add processors (currently only one maximum) to scope in order to avoid
+                      # segfaults because the Ruby objects are GCd before the underlying
+                      # objects are used by parse_query, see for similar problem in php:
+                      # http://grokbase.com/t/xapian/xapian-discuss/079tvjx0wd/segmentation-fault-using-xapiandatevaluerangeprocessor-with-php-bindings
       XapianDb::DocumentBlueprint.searchable_prefixes.each do |prefix|
         parser.add_prefix(prefix.to_s.downcase, "X#{prefix.to_s.upcase}")
         type_info = XapianDb::DocumentBlueprint.type_info_for(prefix)
@@ -42,11 +46,17 @@ module XapianDb
         value_number = XapianDb::DocumentBlueprint.value_number_for(prefix)
         case type_info
           when :date
-            parser.add_valuerangeprocessor Xapian::DateValueRangeProcessor.new(value_number, "#{prefix}:")
+            processor = Xapian::DateValueRangeProcessor.new(value_number, "#{prefix}:")
+            processors << processor
+            parser.add_valuerangeprocessor processor
           when :number
-            parser.add_valuerangeprocessor Xapian::NumberValueRangeProcessor.new(value_number, "#{prefix}:")
+            processor = Xapian::NumberValueRangeProcessor.new(value_number, "#{prefix}:")
+            processors << processor
+            parser.add_valuerangeprocessor processor
           when :string
-            parser.add_valuerangeprocessor Xapian::StringValueRangeProcessor.new(value_number, "#{prefix}:")
+            processor = Xapian::StringValueRangeProcessor.new(value_number, "#{prefix}:")
+            processors << processor
+            parser.add_valuerangeprocessor processor
         end
       end
       query = parser.parse_query(expression, @query_flags)


### PR DESCRIPTION
Wir hatten regelmässig Segfaults mit Ursprung im Aufruf von `parse_query` in `XapianDb::QueryParser#parse`. Der vorliegende PR scheint den Segfault zu flicken. Ursprung scheint das selbe Problem zu sein wie [hier 2007 mit php aufgetaucht ist](http://grokbase.com/t/xapian/xapian-discuss/079tvjx0wd/segmentation-fault-using-xapiandatevaluerangeprocessor-with-php-bindings):

> The issue is with the object lifetime. With your original code, the
> PHP XapianDateValueRangeProcessor object is garbage collected after the
> call to add_valuerangeprocessor, and the underlying C++ object deleted.
